### PR TITLE
Remove auto prefixing of resource names

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -6,8 +6,6 @@ class Resource < ApplicationRecord
 
   audited associated_with: :project
 
-  before_validation :build_name
-
   belongs_to :project,
     -> { readonly },
     inverse_of: :resources
@@ -40,15 +38,6 @@ class Resource < ApplicationRecord
 
   def descriptor
     "#{name} (#{classification})"
-  end
-
-  protected
-
-  def build_name
-    return if persisted? || name.blank? || project.blank?
-    return if name.starts_with?(project.friendly_id)
-
-    self.name = "#{project.friendly_id}_#{name}"
   end
 end
 

--- a/spec/support/is_a_resource_examples.rb
+++ b/spec/support/is_a_resource_examples.rb
@@ -63,6 +63,18 @@ module IsAResourceExamples
             expect(other_resource.errors[:name].first).to eq 'has already been taken'
           end
 
+          it 'does not allow the same name for resources, for the same integration, in different projects' do
+            other_resource = build(
+              factory,
+              name: name,
+              project: other_project,
+              integration: integration
+            )
+
+            expect(other_resource).not_to be_valid
+            expect(other_resource.errors[:name].first).to eq 'has already been taken'
+          end
+
           it 'allows different names for resources, for the same integration, in the same project' do
             other_resource = build(
               factory,
@@ -83,41 +95,6 @@ module IsAResourceExamples
             )
 
             expect(other_resource).to be_valid
-          end
-
-          it 'allows the same name for resources, for the same integration, in different projects' do
-            other_resource = build(
-              factory,
-              name: name,
-              project: other_project,
-              integration: integration
-            )
-
-            expect(other_resource).to be_valid
-          end
-        end
-
-        describe '#build_name' do
-          let(:project) { create :project, name: 'test-project' }
-
-          it 'prefixes the name with the project slug' do
-            resource = create(
-              factory,
-              name: 'foo',
-              project: project,
-              integration: integration
-            )
-            expect(resource.name).to eq "#{project.slug}_foo"
-          end
-
-          it 'can have the same value as the project slug' do
-            resource = create(
-              factory,
-              name: project.slug,
-              project: project,
-              integration: integration
-            )
-            expect(resource.name).to eq project.slug
           end
         end
       end


### PR DESCRIPTION
Previously, any new resource created would have it's name prefixed with the slug of the project (aka space) that resource was contained. This was intended to isolate resources to avoid name clashes between projects/spaces.

However, given the current open projects/spaces model, this prefixing was unnecessary complexity and inflexibility at this stage. We can always add this back in for closed teams/projects/space if/when we get to that.