### PR TITLE
Grafana monitoring dashboards for Kube namespaces

### DIFF
--- a/.env
+++ b/.env
@@ -20,3 +20,6 @@ export KUBERNETES_AGENT_TOKEN="secret-kube-agent-token"
 
 export ECR_AGENT_BASE_URL="http://localhost:10003/api/v1beta"
 export ECR_AGENT_TOKEN="secret-ecr-agent-token"
+
+export GRAFANA_AGENT_BASE_URL="http://localhost:10004/api/v1beta"
+export GRAFANA_AGENT_TOKEN="secret-grafana-agent-token"

--- a/.env.test
+++ b/.env.test
@@ -8,3 +8,9 @@ export QUAY_AGENT_TOKEN="secret-quay-agent-token"
 
 export KUBERNETES_AGENT_BASE_URL="noop"
 export KUBERNETES_AGENT_TOKEN="secret-kube-agent-token"
+
+export ECR_AGENT_BASE_URL="noop"
+export ECR_AGENT_TOKEN="secret-ecr-agent-token"
+
+export GRAFANA_AGENT_BASE_URL="noop"
+export GRAFANA_AGENT_TOKEN="secret-grafana-agent-token"

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'octokit', '~> 4.13'
 gem 'faraday', '~> 0.15.4'
 gem 'faraday_middleware', '~> 0.13.1'
 gem 'typhoeus', '~> 1.3', '>= 1.3.1'
+gem 'closure_tree', '~> 7.0'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,9 @@ GEM
       activemodel (>= 5.0)
     builder (3.2.3)
     byebug (11.0.1)
+    closure_tree (7.0.0)
+      activerecord (>= 4.2.10)
+      with_advisory_lock (>= 4.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
@@ -258,6 +261,8 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    with_advisory_lock (4.0.0)
+      activerecord (>= 4.2)
 
 PLATFORMS
   ruby
@@ -270,6 +275,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap_form (~> 4.2)
   byebug
+  closure_tree (~> 7.0)
   crypt_keeper (~> 2.0, >= 2.0.1)
   default_value_for (~> 3.1)
   dotenv-rails (~> 2.7.2)

--- a/app/agents/grafana_agent.rb
+++ b/app/agents/grafana_agent.rb
@@ -1,0 +1,44 @@
+class GrafanaAgent
+  include AgentHttpClient
+
+  def initialize(agent_base_url:, agent_token:, grafana_url:, grafana_api_key:, grafana_ca_cert:)
+    @agent_base_url = agent_base_url
+    @agent_token = agent_token
+
+    @grafana_url = grafana_url
+    @grafana_api_key = grafana_api_key
+    @grafana_ca_cert = grafana_ca_cert
+  end
+
+  def create_dashboard(name, template_url:)
+    path = dashboard_path name
+    body = {
+      template_url: template_url
+    }
+    client.put do |req|
+      add_grafana_headers req
+      req.url path
+      req.body = body
+    end.body
+  end
+
+  def delete_dashboard(name)
+    path = dashboard_path name
+    client.delete do |req|
+      add_grafana_headers req
+      req.url path
+    end.body
+  end
+
+  private
+
+  def add_grafana_headers(req)
+    req.headers['X-Grafana-URL'] = @grafana_url
+    req.headers['X-Grafana-API-Key'] = @grafana_api_key
+    req.headers['X-Grafana-CA'] = @grafana_ca_cert
+  end
+
+  def dashboard_path(name)
+    "dashboards/#{name}"
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -7,10 +7,13 @@ class ProjectsController < ApplicationController
 
   def show
     @grouped_resources = ResourceTypesService.all.map do |rt|
+      next nil unless rt[:top_level]
+
       integrations = ResourceTypesService.integrations_for rt[:id]
       resources = @project.send rt[:id].tableize
       rt.merge integrations: integrations, resources: resources
-    end
+    end.compact
+
     @activity = ActivityService.new.for_project @project
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,12 +4,18 @@ module ApplicationHelper
       Integration.count.zero?
   end
 
-  def icon(name, size: '1x', title: nil, data_attrs: nil)
-    tag.i '', class: "fas fa-#{name} fa-#{size}", title: title, data: data_attrs
+  def icon(name, size: '1x', css_class: [], title: nil, data_attrs: nil)
+    tag.i '',
+      class: ['fas', "fa-#{name}", "fa-#{size}"] + Array(css_class),
+      title: title,
+      data: data_attrs
   end
 
-  def brand_icon(name, size: '1x', title: nil, data_attrs: nil)
-    tag.i '', class: "fab fa-#{name} fa-#{size}", title: title, data: data_attrs
+  def brand_icon(name, size: '1x', css_class: [], title: nil, data_attrs: nil)
+    tag.i '',
+      class: ['fab', "fa-#{name}", "fa-#{size}"] + Array(css_class),
+      title: title,
+      data: data_attrs
   end
 
   def icon_with_tooltip(text, icon_name: 'question-circle')

--- a/app/helpers/resources_helper.rb
+++ b/app/helpers/resources_helper.rb
@@ -14,20 +14,27 @@ module ResourcesHelper
       brand_icon 'docker'
     when Resources::KubeNamespace, 'Resources::KubeNamespace', 'KubeNamespace'
       icon 'cloud'
+    when Resources::MonitoringDashboard, 'Resources::MonitoringDashboard', 'MonitoringDashboard'
+      icon 'tachometer-alt'
     else
       icon 'cogs'
     end
   end
 
-  def resource_status_class(status)
-    RESOURCE_STATUS_TO_CLASS[status]
+  def resource_status_badge(status, css_class: [])
+    tag.span status,
+      class: [
+        'badge',
+        "badge-#{RESOURCE_STATUS_TO_CLASS[status]}",
+        'text-capitalize'
+      ] + Array(css_class)
   end
 
-  def delete_resource_link(project_id, resource, css_class: nil)
+  def delete_resource_link(project_id, resource, css_class: [])
     link_to 'Delete',
       project_resource_path(project_id, resource),
       method: :delete,
-      class: css_class,
+      class: Array(css_class),
       data: {
         confirm: 'Are you sure you want to delete this resource permanently?',
         title: "Request deletion for resource: #{resource.descriptor}",
@@ -63,6 +70,16 @@ module ResourcesHelper
           'Token' => config['global_service_account_token']
         }
       end
+    end
+  end
+
+  def group_resources_by_resource_type(resources)
+    return [] if resources.blank?
+
+    ResourceTypesService.all.map do |rt|
+      rt.merge(
+        resources: resources.select { |r| r.class.name == rt[:class] }
+      )
     end
   end
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -6,6 +6,8 @@ class Resource < ApplicationRecord
 
   audited associated_with: :project
 
+  has_closure_tree order: 'integration_id', dependent: nil
+
   belongs_to :project,
     -> { readonly },
     inverse_of: :resources

--- a/app/models/resources/monitoring_dashboard.rb
+++ b/app/models/resources/monitoring_dashboard.rb
@@ -1,0 +1,8 @@
+module Resources
+  class MonitoringDashboard < Resource
+    attr_json :url, :string
+
+    # Can only ever be "attached" to another resource
+    validates :parent_id, presence: true
+  end
+end

--- a/app/services/resource_provisioning_service.rb
+++ b/app/services/resource_provisioning_service.rb
@@ -24,4 +24,20 @@ class ResourceProvisioningService
 
     true
   end
+
+  def request_dependent_create(parent_resource, resource_type_id)
+    resource_type = ResourceTypesService.get resource_type_id
+    integrations = ResourceTypesService.integrations_for(resource_type[:id])
+
+    return if integrations.empty?
+
+    resource_class = resource_type[:class].constantize
+    dependent_resource = resource_class.create!(
+      integration: integrations.first,
+      parent: parent_resource,
+      project: parent_resource.project,
+      name: parent_resource.name
+    )
+    request_create dependent_resource
+  end
 end

--- a/app/services/resource_types_service.rb
+++ b/app/services/resource_types_service.rb
@@ -17,19 +17,29 @@ class ResourceTypesService
           id: 'CodeRepo',
           class: 'Resources::CodeRepo',
           name: 'Code Repositories',
+          top_level: true,
           providers: %w[git_hub].freeze
         },
         {
           id: 'DockerRepo',
           class: 'Resources::DockerRepo',
           name: 'Docker Repositories',
+          top_level: true,
           providers: %w[ecr quay].freeze
         },
         {
           id: 'KubeNamespace',
           class: 'Resources::KubeNamespace',
           name: 'Kubernetes Namespaces',
+          top_level: true,
           providers: %w[kubernetes].freeze
+        },
+        {
+          id: 'MonitoringDashboard',
+          class: 'Resources::MonitoringDashboard',
+          name: 'Monitoring Dashboards',
+          top_level: false,
+          providers: %w[grafana].freeze
         }
       ].map(&:freeze).freeze
     end

--- a/app/views/activity/_stream.html.erb
+++ b/app/views/activity/_stream.html.erb
@@ -47,7 +47,7 @@
                 <%= a.auditable_descriptor %>
               </span>
               <% status = 'pending' %>
-              <%= tag.span(status, class: "badge badge-#{resource_status_class(status)}") %>
+              <%= resource_status_badge status %>
               for space:
               <%= link_to a.associated_descriptor, project_path(a.associated_id), class: 'text-monospace' %>
             <% end %>
@@ -61,7 +61,7 @@
                 </span>
                 is now
                 <% status = a.audited_changes['status'].last %>
-                <%= tag.span(status, class: "badge badge-#{resource_status_class(status)}") %>
+                <%= resource_status_badge status %>
                 for space:
                 <%= link_to a.associated_descriptor, project_path(a.associated_id), class: 'text-monospace' %>
               <% end %>
@@ -78,7 +78,7 @@
                 <%= a.auditable_descriptor %>
               </span>
               <% status = 'deleting' %>
-              <%= tag.span(status, class: "badge badge-#{resource_status_class(status)}") %>
+              <%= resource_status_badge status %>
               for space:
               <%= link_to a.associated_descriptor, project_path(a.associated_id), class: 'text-monospace' %>
             <% end %>

--- a/app/views/resources/_list-item.html.erb
+++ b/app/views/resources/_list-item.html.erb
@@ -16,7 +16,7 @@
     <span class="ml-1">
       on <%= resource.integration.name %>
     </span>
-    <%= tag.span(resource.status, class: "badge badge-#{resource_status_class(resource.status)} text-capitalize ml-2") %>
+    <%= resource_status_badge resource.status, css_class: 'ml-2' %>
   </h3>
   <% unless resource.pending? %>
     <div class="mb-2">
@@ -41,34 +41,62 @@
 
     <% credentials = global_credentials_for resource %>
     <% if credentials.present? %>
-      <% panel_id = "credentials-panel-#{resource.id}" %>
-      <%=
-        tag.a(
-          href: '#',
-          data: {
-            toggle: 'collapse',
-            target: "##{panel_id}"
-          },
-          aria: {
-            controls: panel_id
-          }
-        ) do
-      %>
-        Credentials
-      <% end %>
+      <div class="indented mt-3">
+        <% panel_id = "credentials-panel-#{resource.id}" %>
+        <%=
+          tag.a(
+            href: '#',
+            data: {
+              toggle: 'collapse',
+              target: "##{panel_id}"
+            },
+            aria: {
+              controls: panel_id
+            }
+          ) do
+        %>
+          <%= icon 'key' %>
+          Credentials
+          <%= icon 'caret-down', css_class: 'ml-1' %>
+        <% end %>
 
-      <%=
-        tag.div(
-          id: panel_id,
-          class: 'collapse'
-        ) do
-      %>
-        <dl class="mt-2 card p-3 bg-light overflow-auto">
-          <% credentials.each do |(k, v)| %>
-            <dt><%= k -%></dt>
-            <dd class="text-wrap text-break"><%= v -%></dd>
+        <%=
+          tag.div(
+            id: panel_id,
+            class: 'collapse'
+          ) do
+        %>
+          <dl class="mt-2 card p-3 bg-light overflow-auto">
+            <% credentials.each do |(k, v)| %>
+              <dt><%= k -%></dt>
+              <dd class="text-wrap text-break"><%= v -%></dd>
+            <% end %>
+          </dl>
+        <% end %>
+      </div>
+    <% end %>
+
+    <% grouped_resources = group_resources_by_resource_type resource.children %>
+    <% grouped_resources.each do |group| %>
+      <% group[:resources].each do |r| %>
+        <div class="indented mt-3">
+          <%= resource_icon r %>
+          <span class="mr-1">
+            <%= group[:name].singularize -%>:
+          </span>
+          <% if r.active? %>
+            <%= link_to r.name, r.url, target: '_blank' %>
+          <% else %>
+            <%= r.name %>
           <% end %>
-        </dl>
+          <span class="text-muted ml-1">
+            on <%= r.integration.name %>
+          </span>
+          <%= resource_status_badge r.status, css_class: 'ml-2' %>
+          <small class="ml-3">
+            <%= delete_resource_link r.project_id, r %>
+          </small>
+        </div>
       <% end %>
     <% end %>
   <% end %>

--- a/app/webpack/stylesheets/application.scss
+++ b/app/webpack/stylesheets/application.scss
@@ -57,3 +57,8 @@ label.required:after {
   @extend .font-italic;
   @extend .text-muted;
 }
+
+.indented {
+  padding-left: 0.75em;
+  border-left: 2px solid rgba($gray-600, 0.3);
+}

--- a/app/workers/resources/base_worker.rb
+++ b/app/workers/resources/base_worker.rb
@@ -41,6 +41,15 @@ module Resources
           kube_token: config['token'],
           global_service_account_name: config['global_service_account_name']
         )
+      end,
+      'grafana' => lambda do |config|
+        GrafanaAgent.new(
+          agent_base_url: Rails.configuration.agents.grafana.base_url,
+          agent_token: Rails.configuration.agents.grafana.token,
+          grafana_url: config['url'],
+          grafana_api_key: config['api_key'],
+          grafana_ca_cert: config['ca_cert']
+        )
       end
     }.freeze
 

--- a/app/workers/resources/request_create_worker.rb
+++ b/app/workers/resources/request_create_worker.rb
@@ -28,6 +28,17 @@ module Resources
       'Resources::KubeNamespace' => {
         'kubernetes' => lambda do |resource, agent|
           agent.create_namespace resource.name
+
+          ResourceProvisioningService.new.request_dependent_create resource, 'MonitoringDashboard'
+
+          true
+        end
+      },
+      'Resources::MonitoringDashboard' => {
+        'grafana' => lambda do |resource, agent|
+          template_url = resource.integration.config['template_url']
+          result = agent.create_dashboard resource.name, template_url: template_url
+          resource.url = result.url
           true
         end
       }

--- a/app/workers/resources/request_delete_worker.rb
+++ b/app/workers/resources/request_delete_worker.rb
@@ -22,6 +22,12 @@ module Resources
           agent.delete_namespace(resource.name)
           true
         end
+      },
+      'Resources::MonitoringDashboard' => {
+        'grafana' => lambda do |resource, agent|
+          agent.delete_dashboard_dashboard resource.name
+          true
+        end
       }
     }.freeze
 
@@ -30,6 +36,12 @@ module Resources
     end
 
     def finalise(resource)
+      resource_provisioning_service = ResourceProvisioningService.new
+
+      resource.children.each do |r|
+        resource_provisioning_service.request_delete r
+      end
+
       resource.destroy!
     end
   end

--- a/app/workers/resources/request_delete_worker.rb
+++ b/app/workers/resources/request_delete_worker.rb
@@ -25,7 +25,7 @@ module Resources
       },
       'Resources::MonitoringDashboard' => {
         'grafana' => lambda do |resource, agent|
-          agent.delete_dashboard_dashboard resource.name
+          agent.delete_dashboard resource.name
           true
         end
       }

--- a/config/initializers/agents.rb
+++ b/config/initializers/agents.rb
@@ -2,6 +2,7 @@ agents_config = %i[
   ecr
   quay
   kubernetes
+  grafana
 ].each_with_object(ActiveSupport::OrderedOptions.new) do |a, h|
   h.send(
     "#{a}=",

--- a/config/providers.yml
+++ b/config/providers.yml
@@ -142,3 +142,30 @@
       - token
       - global_service_account_name
       - global_service_account_token
+
+- id: grafana
+  name: Grafana
+  config_spec:
+    properties:
+      url:
+        title: Grafana URL
+        description: The URL to this Grafana instance.
+        type: string
+      api_key:
+        title: Grafana API key
+        description: The API key used when talking to this Grafana instance.
+        type: string
+        masked: true
+      ca_cert:
+        title: CA certificate
+        description: MUST be base64 encoded. This is the CA bundle (pem format) for requests to the Grafana API.
+        type: string
+        masked: true
+      template_url:
+        title: Dashboard template URL
+        description: A URL to a dashboard template (in Golang templated format) that will be used when creating the dashboard on Grafana.
+        type: string
+    required:
+      - url
+      - api_key
+      - template_url

--- a/db/migrate/20190501141450_add_parent_id_to_resources.rb
+++ b/db/migrate/20190501141450_add_parent_id_to_resources.rb
@@ -1,0 +1,5 @@
+class AddParentIdToResources < ActiveRecord::Migration[5.2]
+  def change
+    add_column :resources, :parent_id, :uuid, index: true
+  end
+end

--- a/db/migrate/20190501143452_create_resource_hierarchies.rb
+++ b/db/migrate/20190501143452_create_resource_hierarchies.rb
@@ -1,0 +1,18 @@
+class CreateResourceHierarchies < ActiveRecord::Migration[5.2]
+  # rubocop:disable Rails/CreateTableWithTimestamps
+  def change
+    create_table :resource_hierarchies, id: false do |t|
+      t.uuid :ancestor_id, null: false
+      t.uuid :descendant_id, null: false
+      t.integer :generations, null: false
+    end
+
+    add_index :resource_hierarchies, %i[ancestor_id descendant_id generations],
+      unique: true,
+      name: 'resource_anc_desc_idx'
+
+    add_index :resource_hierarchies, [:descendant_id],
+      name: 'resource_desc_idx'
+  end
+  # rubocop:enable Rails/CreateTableWithTimestamps
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_24_123818) do
+ActiveRecord::Schema.define(version: 2019_05_01_143452) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -62,6 +62,14 @@ ActiveRecord::Schema.define(version: 2019_04_24_123818) do
     t.index ["slug"], name: "index_projects_on_slug", unique: true
   end
 
+  create_table "resource_hierarchies", id: false, force: :cascade do |t|
+    t.uuid "ancestor_id", null: false
+    t.uuid "descendant_id", null: false
+    t.integer "generations", null: false
+    t.index ["ancestor_id", "descendant_id", "generations"], name: "resource_anc_desc_idx", unique: true
+    t.index ["descendant_id"], name: "resource_desc_idx"
+  end
+
   create_table "resources", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "type", null: false
     t.uuid "project_id", null: false
@@ -72,6 +80,7 @@ ActiveRecord::Schema.define(version: 2019_04_24_123818) do
     t.string "lock_version"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "parent_id"
     t.index ["integration_id"], name: "index_resources_on_integration_id"
     t.index ["name", "integration_id"], name: "index_resources_on_name_and_integration_id", unique: true
     t.index ["project_id"], name: "index_resources_on_project_id"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       - 10003:10003
 
   grafana_agent:
-    image: quay.io/appvia/hub-grafana-agent:v0.0.1-rc1
+    image: quay.io/appvia/hub-grafana-agent:v0.0.1
     environment:
       - DEBUG=true
       - HTTP_PORT=10004

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,5 +85,15 @@ services:
     ports:
       - 10003:10003
 
+  grafana_agent:
+    image: quay.io/appvia/hub-grafana-agent:v0.0.1-rc1
+    environment:
+      - DEBUG=true
+      - HTTP_PORT=10004
+      - LISTEN=0.0.0.0
+      - AUTH_TOKEN=secret-grafana-agent-token
+    ports:
+      - 10004:10004
+
 volumes:
   pgdata:

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -14,5 +14,11 @@ FactoryBot.define do
 
     factory :kube_namespace, class: 'Resources::KubeNamespace' do
     end
+
+    factory :monitoring_dashboard, class: 'Resources::MonitoringDashboard' do
+      # NOTE: this factory will not produce a valid model object out of the box
+      # - you will need to set the `parent` association yourself (to another
+      # valid resource).
+    end
   end
 end

--- a/spec/integration/resources/kube_namespaces/kubernetes_kube_namespaces_integration_spec.rb
+++ b/spec/integration/resources/kube_namespaces/kubernetes_kube_namespaces_integration_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe 'Kube Namespaces – Kubernetes' do
       }
     end
 
+    let :dependent_type do
+      'MonitoringDashboard'
+    end
+
+    let :dependent_integration do
+      create_mocked_integration provider_id: 'grafana'
+    end
+
     let :agent_create_response do
       double
     end
@@ -63,6 +71,9 @@ RSpec.describe 'Kube Namespaces – Kubernetes' do
 
     let :request_delete_before_setup_resource_state do
       lambda do |resource|
+        create :monitoring_dashboard,
+          integration: dependent_integration,
+          parent: resource
       end
     end
 

--- a/spec/integration/resources/monitoring_dashboards/grafana_monitoring_dashboards_integration_spec.rb
+++ b/spec/integration/resources/monitoring_dashboards/grafana_monitoring_dashboards_integration_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe 'Monitoring Dashboards – Grafana' do
+  include_examples 'resource integration specs' do
+    let(:provider_id) { 'grafana' }
+
+    let :integration_config do
+      {
+        'url' => 'http://grafana',
+        'api_key' => 'this is an API key, no really',
+        'ca_cert' => 'ca cert base64 encoded',
+        'template_url' => 'http://url.to.my.template/foo'
+      }
+    end
+
+    let! :parent do
+      kubernetes_integration = create_mocked_integration provider_id: 'kubernetes'
+      create :kube_namespace, integration: kubernetes_integration
+    end
+
+    let! :resource do
+      create :monitoring_dashboard,
+        parent: parent,
+        integration: integration
+    end
+
+    let(:agent_class) { GrafanaAgent }
+    let :agent_initializer_params do
+      {
+        agent_base_url: Rails.configuration.agents.grafana.base_url,
+        agent_token: Rails.configuration.agents.grafana.token,
+        grafana_url: integration_config['url'],
+        grafana_api_key: integration_config['api_key'],
+        grafana_ca_cert: integration_config['ca_cert']
+      }
+    end
+
+    let :agent_create_response do
+      double(
+        url: 'http://grafana/my-new-dashboard'
+      )
+    end
+
+    let :agent_create_method_call_success do
+      lambda do |agent, resource|
+        expect(agent).to receive(:create_dashboard)
+          .with(resource.name, template_url: integration_config['template_url'])
+          .and_return(agent_create_response)
+      end
+    end
+
+    let :request_create_finished_success_expectations do
+      lambda do |updated|
+        expect(updated.url).to eq agent_create_response.url
+      end
+    end
+
+    let :agent_create_method_call_error do
+      lambda do |agent, resource|
+        expect(agent).to receive(:create_dashboard)
+          .with(resource.name, template_url: integration_config['template_url'])
+          .and_raise('Something broked')
+      end
+    end
+
+    let :request_create_finished_error_expectations do
+      lambda do |updated|
+        expect(updated.url).to eq nil
+      end
+    end
+
+    let :request_delete_before_setup_resource_state do
+      lambda do |resource|
+      end
+    end
+
+    let :agent_delete_method_call_success do
+      lambda do |agent, resource|
+        expect(agent).to receive(:delete_dashboard)
+          .with(resource.name)
+          .and_return(true)
+      end
+    end
+
+    let :agent_delete_method_call_error do
+      lambda do |agent, resource|
+        expect(agent).to receive(:delete_dashboard)
+          .with(resource.name)
+          .and_raise('Something broked')
+      end
+    end
+  end
+end

--- a/spec/models/integration_spec.rb
+++ b/spec/models/integration_spec.rb
@@ -85,13 +85,12 @@ RSpec.describe Integration, type: :model do
         { 'foo' => '1' }
       end
 
-      before do
-        expect(PROVIDERS_REGISTRY).to receive(:config_schemas)
-          .and_return(provider_id => schema)
-      end
-
       subject do
-        create_mocked_integration provider_id: provider_id, config: initial_config
+        create_mocked_integration(
+          provider_id: provider_id,
+          config: initial_config,
+          schema: schema
+        )
       end
 
       it 'ensures that boolean fields are stored in the correct format' do
@@ -121,6 +120,10 @@ RSpec.describe Integration, type: :model do
       end
 
       before do
+        # NOTE: usually in specs you MUST use the `mock_provider_config_schema`
+        # helper to mock out config schemas. However, in this special case, we
+        # need to test the actual validation flow without it being mocked out.
+        # Hence the line below instead:
         allow(PROVIDERS_REGISTRY).to receive(:config_schemas)
           .and_return(provider_id => schema)
       end

--- a/spec/support/mocked_integration_helper.rb
+++ b/spec/support/mocked_integration_helper.rb
@@ -1,23 +1,27 @@
 module MockedIntegrationHelper
   RSpec.shared_context 'mocked integration helper' do
-    let(:config_schema) { instance_double(JsonSchema::Schema, properties: {}) }
+    let(:empty_config_schema) { instance_double(JsonSchema::Schema, properties: {}) }
 
-    def mock_provider_config_schema(provider_id)
+    def mock_provider_config_schema(provider_id, schema: nil)
+      schema = empty_config_schema if schema.blank?
+
+      updated_config_schemas = PROVIDERS_REGISTRY.config_schemas.merge(
+        provider_id => schema
+      )
+
       allow(PROVIDERS_REGISTRY).to receive(:config_schemas)
-        .and_return(provider_id => config_schema)
+        .and_return(updated_config_schemas)
+
+      allow(schema).to receive(:validate!)
+        .and_return(true)
     end
 
-    def create_mocked_integration(provider_id: Integration.provider_ids.keys.first, config: { 'foo' => 'bar' })
-      mock_provider_config_schema provider_id
+    def create_mocked_integration(provider_id: Integration.provider_ids.keys.first, config: { 'foo' => 'bar' }, schema: nil)
+      mock_provider_config_schema provider_id, schema: schema
 
       create :integration,
         provider_id: provider_id,
         config: config
-    end
-
-    before do
-      allow(config_schema).to receive(:validate!)
-        .and_return(true)
     end
   end
 end

--- a/spec/support/resource_integration_specs_examples.rb
+++ b/spec/support/resource_integration_specs_examples.rb
@@ -2,13 +2,13 @@ module ResourceIntegrationSpecsExamples
   RSpec.shared_examples 'resource integration specs' do
     include_context 'time helpers'
 
-    let :integration do
+    let! :integration do
       create :integration,
         provider_id: provider_id,
         config: integration_config
     end
 
-    let :provisioning_service do
+    let! :provisioning_service do
       ResourceProvisioningService.new
     end
 
@@ -20,12 +20,33 @@ module ResourceIntegrationSpecsExamples
       expect(agent_class).to receive(:new)
         .with(**agent_initializer_params)
         .and_return(agent)
+
+      allow(ResourceProvisioningService).to receive(:new)
+        .and_return(provisioning_service)
+    end
+
+    let :dependent_type do
+      nil
+    end
+
+    let :dependent_integration do
+      nil
     end
 
     describe 'request create' do
       context 'when agent doesn\'t throw an error' do
         before do
           agent_create_method_call_success.call(agent, resource)
+
+          if dependent_type.present?
+            expect(provisioning_service).to receive(:request_dependent_create)
+              .with(resource, dependent_type)
+              .and_call_original
+
+            expect(ResourceTypesService).to receive(:integrations_for)
+              .with(dependent_type)
+              .and_return([dependent_integration])
+          end
         end
 
         it 'works as expected' do
@@ -39,7 +60,9 @@ module ResourceIntegrationSpecsExamples
 
           expect(resource.audits.order(:created_at).last.action).to eq 'request_create'
 
-          Sidekiq::Worker.drain_all
+          move_time_to 1.minute.from_now
+
+          Resources::RequestCreateWorker.perform_one
 
           updated = Resource.find resource.id
 
@@ -47,18 +70,37 @@ module ResourceIntegrationSpecsExamples
           expect(updated.status).to eq Resource.statuses[:active]
 
           request_create_finished_success_expectations.call updated
+
+          if dependent_type.present?
+            expect(Resources::RequestCreateWorker.jobs.size).to eq 1
+            worker = Resources::RequestCreateWorker.jobs.first
+
+            expect(updated.children.length).to eq 1
+            dependent = updated.children.first
+
+            expect(worker['args']).to contain_exactly dependent.id
+
+            expect(dependent.integration).to eq dependent_integration
+            expect(dependent.project).to eq resource.project
+            expect(dependent.name).to eq resource.name
+            expect(dependent.status).to eq Resource.statuses[:pending]
+
+            expect(dependent.audits.order(:created_at).last.action).to eq 'request_create'
+          end
         end
       end
 
       context 'when agent throws an error' do
         before do
           agent_create_method_call_error.call(agent, resource)
+
+          expect(provisioning_service).to receive(:request_dependent_create).never if dependent_type.present?
         end
 
         it 'marks the resource as failed' do
           provisioning_service.request_create resource
 
-          Sidekiq::Worker.drain_all
+          Resources::RequestCreateWorker.perform_one
 
           updated = Resource.find resource.id
 
@@ -85,6 +127,8 @@ module ResourceIntegrationSpecsExamples
         it 'works as expected' do
           move_time_to 1.minute.from_now
 
+          dependent = (resource.children.first if dependent_type.present?)
+
           expect do
             provisioning_service.request_delete resource
           end.to change(Resources::RequestDeleteWorker.jobs, :size).by(1)
@@ -93,9 +137,18 @@ module ResourceIntegrationSpecsExamples
 
           expect(resource.audits.order(:created_at).last.action).to eq 'request_delete'
 
-          Sidekiq::Worker.drain_all
+          move_time_to 1.minute.from_now
+
+          Resources::RequestDeleteWorker.perform_one
 
           expect(Resource.exists?(resource.id)).to be false
+
+          if dependent.present?
+            expect(Resources::RequestDeleteWorker.jobs.size).to eq 1
+            worker = Resources::RequestDeleteWorker.jobs.first
+            expect(worker['args']).to contain_exactly dependent.id
+            expect(dependent.reload.status).to eq Resource.statuses[:deleting]
+          end
         end
       end
 
@@ -107,11 +160,16 @@ module ResourceIntegrationSpecsExamples
         it 'marks the resource as failed' do
           provisioning_service.request_delete resource
 
-          Sidekiq::Worker.drain_all
+          Resources::RequestDeleteWorker.perform_one
 
           updated = Resource.find resource.id
 
           expect(updated.status).to eq Resource.statuses[:failed]
+
+          if dependent_type.present?
+            expect(Resources::RequestDeleteWorker.jobs.size).to eq 0
+            expect(resource.children.size).to eq 1
+          end
         end
       end
     end


### PR DESCRIPTION
Part of #117

Highlights:

- Introduces the concept of "dependent" resources – a resource that is dependent on another.
- In this case, a `MonitoringDashboard` resource (which has been added in this PR) can only exist if it is "attached" to another resource…
- … currently to `KubeNamespace` resources.
- Thus the create and delete workers for `KubeNamespace` make sure to request create / delete of a dependent `MonitoringDashboard` resource.
- And the UI shows these "embedded" within the `KubeNamespace` entry.

---

**TODO:**

- [x] Specs for the new bits (especially: updating the Kube namespace integration spec)
- [x] Thorough end-to-end testing locally