### PR TITLE
Don't provision a separate monitoring dashboard as part of the project resources bootstrap

### DIFF
--- a/app/services/project_resources_bootstrap_service.rb
+++ b/app/services/project_resources_bootstrap_service.rb
@@ -8,13 +8,15 @@ class ProjectResourcesBootstrapService
     return false if @project.resources.count.positive?
 
     ResourceTypesService.all.map do |rt|
+      next nil unless rt[:top_level]
+
       integration = ResourceTypesService.integrations_for(rt[:id]).first
       resource = {
         name: @project.slug,
         integration: integration
       }
       rt.merge resource: resource
-    end
+    end.compact
   end
 
   def bootstrap


### PR DESCRIPTION
One will get provisioning _after_ the Kube namespace.