### PR TITLE
Auth logout

### DIFF
--- a/.env
+++ b/.env
@@ -12,6 +12,8 @@ export AHUB_DB_NAME=ahub
 
 export REDIS_URL="redis://localhost:6379"
 
+export AUTH_LOGOUT_URL="http://localhost:3000/oauth/logout?redirect=http%3A%2F%2Flocalhost%3A3000"
+
 export QUAY_AGENT_BASE_URL="http://localhost:10001/api/v1beta"
 export QUAY_AGENT_TOKEN="secret-quay-agent-token"
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   before_action :record_last_seen!
 
   helper_method :current_user
+  helper_method :current_user?
 
   protected
 

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -6,9 +6,9 @@ module Authentication
   extend Memoist
 
   AUTH_HEADERS = {
-    subject: ENV['AUTH_SUB_HEADER'] || 'X-Auth-Subject',
-    email: ENV['AUTH_EMAIL_HEADER'] || 'X-Auth-Email',
-    name: ENV['AUTH_NAME_HEADER'] || 'X-Auth-Username'
+    subject: Rails.configuration.x.auth.sub_header,
+    email: Rails.configuration.x.auth.email_header,
+    name: Rails.configuration.x.auth.name_header
   }.freeze
 
   def require_authentication

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -1,12 +1,24 @@
 <header class="site-header">
-  <nav class="navbar navbar-dark fixed-top bg-gradient-primary flex-md-nowrap p-0">
+  <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-gradient-primary flex-md-nowrap p-0">
     <a class="navbar-brand col-sm-3 col-md-2 mr-0" href="/">
       <%= image_tag(asset_pack_path('media/images/appvia_logo_white.svg'), class: 'logo d-inline-block align-top', alt: 'Appvia Logo') %>
     </a>
-    <ul class="navbar-nav px-3 ml-auto">
-      <li class="nav-item text-nowrap text-light">
-        <%= current_user.try(:email) %>
-      </li>
-    </ul>
+    <% if current_user? %>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarCollapse">
+        <ul class="nav navbar-nav navbar-right ml-auto mr-3">
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="navbarUserDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <%= current_user.email %>
+            </a>
+            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarUserDropdown">
+              <%= link_to 'Log out', Rails.configuration.x.auth.logout_url, class: 'dropdown-item' %>
+            </div>
+          </li>
+        </ul>
+      </div>
+    <% end %>
   </nav>
 </header>

--- a/app/webpack/stylesheets/_variables.scss
+++ b/app/webpack/stylesheets/_variables.scss
@@ -4,6 +4,8 @@
 // - https://getbootstrap.com/docs/4.2/getting-started/theming/
 // - https://github.com/twbs/bootstrap/blob/v4.2.1/scss/_variables.scss
 
+$navbar-dark-hover-color: $yellow;
+
 // ----------------------------------------------------------------------------
 // Other variables
 

--- a/config/initializers/authentication.rb
+++ b/config/initializers/authentication.rb
@@ -1,0 +1,6 @@
+Rails.application.configure do
+  config.x.auth.sub_header = ENV.fetch('AUTH_SUB_HEADER', 'X-Auth-Subject')
+  config.x.auth.email_header = ENV.fetch('AUTH_EMAIL_HEADER', 'X-Auth-Email')
+  config.x.auth.name_header = ENV.fetch('AUTH_NAME_HEADER', 'X-Auth-Username')
+  config.x.auth.logout_url = ENV.fetch('AUTH_LOGOUT_URL', '/oauth/logout')
+end


### PR DESCRIPTION
Closes #67

A new config option is now available – `AUTH_LOGOUT_URL` – to specify the logout URL (that needs to be handled by the auth proxy).

Note: this currently doesn't work properly with the local Keycloak Gatekeeper setup – it errors with a `400` error. More investigation is required (which we can do separately).