### PR TITLE
GitHub code repos access for users

### DIFF
--- a/.env
+++ b/.env
@@ -4,6 +4,10 @@
 
 export PORT=3001
 
+# App specific config
+
+export BASE_URL="http://localhost:3000"
+
 # If using the Docker Compose set up then these should match the values there:
 export AHUB_DB_USER=ahub
 export AHUB_DB_PASSWORD=ahub_password

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,12 @@ RUN yarn install --frozen-lockfile --no-cache --production
 COPY . /app
 
 # precompile assets
-RUN SECRET_KEY_BASE=foo SECRET_SALT=bar DATABASE_URL=postgresql://user:pass@127.0.0.1/dbname bin/rails assets:precompile \
- && rm -rf node_modules tmp/cache app/webpack
+RUN BASE_URL=noop \
+  SECRET_KEY_BASE=foo \
+  SECRET_SALT=bar \
+  DATABASE_URL=postgresql://user:pass@127.0.0.1/dbname \
+  bin/rails assets:precompile \
+  && rm -rf node_modules tmp/cache app/webpack
 
 ##############################################################
 # Stage: final

--- a/app/agents/git_hub_agent.rb
+++ b/app/agents/git_hub_agent.rb
@@ -8,7 +8,7 @@ class GitHubAgent
     setup_client
   end
 
-  def create_repository(name, private: false, best_practices: false)
+  def create_repository(name, team_id:, private: false, best_practices: false)
     client = app_installation_client
 
     resource = find_or_create_repo(
@@ -20,6 +20,8 @@ class GitHubAgent
 
     apply_best_practices client, resource.full_name if best_practices
 
+    client.add_team_repository team_id, resource.full_name, permission: 'admin'
+
     resource
   end
 
@@ -27,6 +29,20 @@ class GitHubAgent
     return unless app_installation_client.repository? full_name
 
     app_installation_client.delete_repository(full_name)
+  end
+
+  def add_user_to_team(team_id, username)
+    app_installation_client.add_team_membership(
+      team_id,
+      username
+    )
+  end
+
+  def remove_user_from_team(team_id, username)
+    app_installation_client.remove_team_member(
+      team_id,
+      username
+    )
   end
 
   private

--- a/app/agents/git_hub_agent.rb
+++ b/app/agents/git_hub_agent.rb
@@ -35,7 +35,7 @@ class GitHubAgent
     payload = {
       iat: Time.now.to_i,
       exp: Time.now.to_i + (10 * 60), # Max is 10 mins
-      iss: @app_id
+      iss: @app_id.to_s
     }
 
     jwt = JWT.encode payload, @app_private_key, 'RS256'

--- a/app/controllers/me/access_controller.rb
+++ b/app/controllers/me/access_controller.rb
@@ -1,0 +1,23 @@
+module Me
+  class AccessController < ApplicationController
+    def show
+      identities_by_integration = current_user
+        .identities
+        .group_by(&:integration_id)
+        .transform_values(&:first)
+
+      @groups = ResourceTypesService.all.map do |rt|
+        integrations = ResourceTypesService.integrations_for(rt[:id]).order(:provider_id)
+
+        entries = integrations.map do |i|
+          {
+            integration: i,
+            identity: identities_by_integration[i.id]
+          }
+        end
+
+        rt.merge entries: entries
+      end
+    end
+  end
+end

--- a/app/controllers/me/identities_controller.rb
+++ b/app/controllers/me/identities_controller.rb
@@ -1,0 +1,21 @@
+module Me
+  class IdentitiesController < ApplicationController
+    before_action :find_integration
+
+    def destroy
+      identity = current_user.identities.find_by(integration_id: @integration.id)
+
+      raise ActiveRecord::RecordNotFound if identity.blank?
+
+      identity.destroy!
+
+      redirect_to me_access_path, notice: 'Identity disconnected'
+    end
+
+    private
+
+    def find_integration
+      @integration = Integration.find params[:integration_id]
+    end
+  end
+end

--- a/app/controllers/me/identity_flows_controller.rb
+++ b/app/controllers/me/identity_flows_controller.rb
@@ -1,0 +1,69 @@
+module Me
+  class IdentityFlowsController < ApplicationController
+    ACTION_TO_PROVIDER_IDS = {
+      'git_hub_start' => 'git_hub',
+      'git_hub_callback' => 'git_hub'
+    }.freeze
+
+    skip_before_action :require_authentication, only: :git_hub_callback
+
+    before_action :find_integration
+
+    before_action :ensure_valid_action_for_integration
+
+    def git_hub_start
+      callback_url = URI.join(
+        Rails.configuration.base_url,
+        me_identity_flow_git_hub_callback_path(integration_id: @integration.id)
+      ).to_s
+
+      redirect_to git_hub_identity_service.authorize_url(
+        current_user,
+        callback_url
+      )
+    end
+
+    # Called by GitHub as part of it's OAuth2 flow
+    def git_hub_callback
+      code, state = params.require(%i[code state])
+
+      begin
+        git_hub_identity_service.connect_identity @integration, code, state
+      rescue GitHubIdentityService::InvalidCallbackState
+        logger.error "GitHub identity flow callback was called with an invalid 'state' = #{state}"
+        head(:forbidden) && return
+      rescue GitHubIdentityService::NoAccessToken
+        logger.error 'GitHub identity flow was unable to get an access token'
+        head(:forbidden) && return
+      rescue GitHubIdentityService::MismatchWithExistingUser
+        logger.error [
+          "GitHub identity flow returned a GitHub user already connected to a different hub user's identity (i.e. different to the user specified",
+          "in the 'state' at the beginning of the auth flow)"
+        ].join(' ')
+        head(:forbidden) && return
+      end
+
+      redirect_to me_access_path, notice: 'GitHub identity connected'
+    end
+
+    private
+
+    def find_integration
+      @integration = Integration.find params[:integration_id]
+    end
+
+    def ensure_valid_action_for_integration
+      unprocessable_entity_error if ACTION_TO_PROVIDER_IDS[action_name] != @integration.provider_id
+    end
+
+    def git_hub_identity_service
+      config = @integration.config
+
+      GitHubIdentityService.new(
+        encryption_service: ENCRYPTOR,
+        client_id: config['app_client_id'],
+        client_secret: config['app_client_secret']
+      )
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,8 +36,9 @@ module ApplicationHelper
       data: data_attrs
   end
 
-  def icon_with_tooltip(text, icon_name: 'question-circle')
+  def icon_with_tooltip(text, icon_name: 'question-circle', css_class: [])
     icon icon_name,
+      css_class: css_class,
       title: text,
       data_attrs: {
         toggle: 'tooltip'

--- a/app/helpers/integrations_helper.rb
+++ b/app/helpers/integrations_helper.rb
@@ -6,4 +6,36 @@ module IntegrationsHelper
       name.humanize
     end
   end
+
+  def global_credentials_for(integration)
+    config = integration.config
+    provider_id = integration.provider_id
+    resource_type = ResourceTypesService.for_integration integration
+
+    case resource_type[:id]
+    when 'DockerRepo'
+      case provider_id
+      when 'quay'
+        {
+          'Robot name' => config['global_robot_name'],
+          'Robot token' => config['global_robot_token']
+        }
+      when 'ecr'
+        {
+          'Robot Username' => config['global_robot_name'],
+          'Robot Access ID' => config['global_robot_access_id'],
+          'Robot Secret' => config['global_robot_token']
+        }
+      end
+    when 'KubeNamespace'
+      case provider_id
+      when 'kubernetes'
+        {
+          'Kube API' => config['api_url'],
+          'CA cert' => config['ca_cert'],
+          'Token' => config['global_service_account_token']
+        }
+      end
+    end
+  end
 end

--- a/app/helpers/resources_helper.rb
+++ b/app/helpers/resources_helper.rb
@@ -46,35 +46,6 @@ module ResourcesHelper
       role: 'button'
   end
 
-  def global_credentials_for(resource)
-    config = resource.integration.config
-    case resource
-    when Resources::DockerRepo
-      case resource.integration.provider_id
-      when 'quay'
-        {
-          'Robot name' => config['global_robot_name'],
-          'Robot token' => config['global_robot_token']
-        }
-      when 'ecr'
-        {
-          'Robot Username' => config['global_robot_name'],
-          'Robot Access ID' => config['global_robot_access_id'],
-          'Robot Secret' => config['global_robot_token']
-        }
-      end
-    when Resources::KubeNamespace
-      case resource.integration.provider_id
-      when 'kubernetes'
-        {
-          'Kube API' => config['api_url'],
-          'CA cert' => config['ca_cert'],
-          'Token' => config['global_service_account_token']
-        }
-      end
-    end
-  end
-
   def group_resources_by_resource_type(resources)
     return [] if resources.blank?
 

--- a/app/lib/json_schema_helpers.rb
+++ b/app/lib/json_schema_helpers.rb
@@ -1,11 +1,15 @@
 module JsonSchemaHelpers
-  # Processes a flat Hash of values, converting fields that are meant to be
-  # a Boolean, based on the provided JsonSchema spec
-  def self.ensure_booleans(data, spec)
+  # Processes a flat Hash of values, ensuring fields are converted to the data
+  # type specified in the provided JsonSchema spec.
+  def self.ensure_data_types(data, spec)
     return data if data.blank?
 
     spec.properties.each do |(name, property_spec)|
-      data[name] = ActiveRecord::Type::Boolean.new.cast(data[name]) if property_spec.type.include?('boolean')
+      if property_spec.type.include?('boolean')
+        data[name] = ActiveRecord::Type::Boolean.new.cast(data[name])
+      elsif property_spec.type.include?('integer')
+        data[name] = data[name].to_i
+      end
     end
 
     data

--- a/app/models/concerns/encrypted_config_hash_attribute.rb
+++ b/app/models/concerns/encrypted_config_hash_attribute.rb
@@ -38,7 +38,7 @@ module EncryptedConfigHashAttribute
     return if config.blank?
 
     with_config_schema do |schema|
-      self.config = JsonSchemaHelpers.ensure_booleans(config, schema)
+      self.config = JsonSchemaHelpers.ensure_data_types(config, schema)
     end
   end
 

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -1,0 +1,44 @@
+class Identity < ApplicationRecord
+  audited associated_with: :user
+
+  belongs_to :user
+  validates :user_id, presence: true
+
+  belongs_to :integration
+  validates :integration_id,
+    presence: true,
+    uniqueness: { scope: :user_id }
+
+  validates :external_id,
+    presence: true,
+    uniqueness: { scope: :integration_id }
+
+  after_create_commit :trigger_created_worker
+  after_destroy_commit :trigger_deleted_worker
+
+  def descriptor
+    "For integration: #{integration.name}"
+  end
+
+  def external_info
+    {
+      'ID' => external_id,
+      'Username' => external_username,
+      'Name' => external_name,
+      'Email' => external_email
+    }.compact
+  end
+
+  private
+
+  def trigger_created_worker
+    HandleIdentityCreatedWorker.perform_async id
+  end
+
+  def trigger_deleted_worker
+    HandleIdentityDeletedWorker.perform_async(
+      integration.id,
+      external_info
+    )
+  end
+end

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -5,10 +5,6 @@ class Integration < ApplicationRecord
 
   enum provider_id: PROVIDERS_REGISTRY.ids.each_with_object({}) { |id, acc| acc[id] = id }
 
-  has_many :resources,
-    dependent: :restrict_with_exception,
-    inverse_of: :integration
-
   validates :name,
     presence: true,
     uniqueness: true
@@ -18,6 +14,15 @@ class Integration < ApplicationRecord
   validates :config, presence: true
 
   attr_readonly :provider_id
+
+  has_many :resources,
+    dependent: :restrict_with_exception,
+    inverse_of: :integration
+
+  has_many :user_identities,
+    class_name: 'Identity',
+    dependent: :restrict_with_exception,
+    inverse_of: :integration
 
   def provider
     return if provider_id.blank?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,9 @@ class User < ApplicationRecord
 
   default_value_for :role, 'user'
 
+  has_many :identities,
+    dependent: :destroy
+
   def descriptor
     email
   end

--- a/app/services/agents_service.rb
+++ b/app/services/agents_service.rb
@@ -1,0 +1,64 @@
+module AgentsService
+  class << self
+    AGENT_INITIALISERS = {
+      'git_hub' => lambda do |config|
+        GitHubAgent.new(
+          app_id: config['app_id'],
+          app_private_key: config['app_private_key'],
+          app_installation_id: config['app_installation_id'],
+          org: config['org']
+        )
+      end,
+      'ecr' => lambda do |config|
+        ECRAgent.new(
+          agent_base_url: Rails.configuration.agents.ecr.base_url,
+          agent_token: Rails.configuration.agents.ecr.token,
+          org: config['org'],
+          access_id: config['access_id'],
+          access_token: config['access_token'],
+          region: config['region'],
+          account: config['account'],
+          global_robot_name: config['global_robot_name']
+        )
+      end,
+      'quay' => lambda do |config|
+        QuayAgent.new(
+          agent_base_url: Rails.configuration.agents.quay.base_url,
+          agent_token: Rails.configuration.agents.quay.token,
+          quay_access_token: config['api_access_token'],
+          org: config['org'],
+          global_robot_name: config['global_robot_name']
+        )
+      end,
+      'kubernetes' => lambda do |config|
+        KubernetesAgent.new(
+          agent_base_url: Rails.configuration.agents.kubernetes.base_url,
+          agent_token: Rails.configuration.agents.kubernetes.token,
+          kube_api_url: config['api_url'],
+          kube_ca_cert: config['ca_cert'],
+          kube_token: config['token'],
+          global_service_account_name: config['global_service_account_name']
+        )
+      end,
+      'grafana' => lambda do |config|
+        GrafanaAgent.new(
+          agent_base_url: Rails.configuration.agents.grafana.base_url,
+          agent_token: Rails.configuration.agents.grafana.token,
+          grafana_url: config['url'],
+          grafana_api_key: config['api_key'],
+          grafana_ca_cert: config['ca_cert']
+        )
+      end,
+      'loki' => lambda do |config|
+        LokiAgent.new(
+          grafana_url: config['grafana_url']
+        )
+      end
+    }.freeze
+
+    def get(provider_id, config)
+      agent_initialiser = AGENT_INITIALISERS[provider_id]
+      agent_initialiser&.call config
+    end
+  end
+end

--- a/app/services/encryptor_service.rb
+++ b/app/services/encryptor_service.rb
@@ -1,0 +1,20 @@
+class EncryptorService
+  def initialize(secret_key_base)
+    @encryptor = ActiveSupport::MessageEncryptor.new(
+      Digest::MD5.hexdigest( # Ensure we use a 32 byte key regardless
+        secret_key_base
+      )
+    )
+  end
+
+  def encrypt(plaintext)
+    @encryptor.encrypt_and_sign(plaintext)
+  end
+
+  def decrypt(encrypted_data)
+    @encryptor.decrypt_and_verify(encrypted_data)
+  rescue ActiveSupport::MessageVerifier::InvalidSignature,
+         ActiveSupport::MessageEncryptor::InvalidMessage
+    nil
+  end
+end

--- a/app/services/git_hub_identity_service.rb
+++ b/app/services/git_hub_identity_service.rb
@@ -1,0 +1,63 @@
+class GitHubIdentityService
+  def initialize(encryption_service:, client_id:, client_secret:)
+    @encryption_service = encryption_service
+    @client_id = client_id
+    @client_secret = client_secret
+  end
+
+  def authorize_url(user, callback_url)
+    Octokit::Client.new.authorize_url(
+      @client_id,
+        scope: '',
+        redirect_uri: callback_url,
+        state: Base64.urlsafe_encode64(@encryption_service.encrypt(user.id))
+    )
+  end
+
+  def connect_identity(integration, code, state)
+    user_id = @encryption_service.decrypt(Base64.urlsafe_decode64(state))
+    user = User.find_by id: user_id
+
+    raise InvalidCallbackState if user.blank?
+
+    result = Octokit.exchange_code_for_token(code, @client_id, @client_secret)
+    access_token = result[:access_token]
+
+    raise NoAccessToken if access_token.blank?
+
+    github_client = Octokit::Client.new
+    github_client.access_token = access_token
+    github_user = github_client.user
+
+    identity = integration.user_identities.find_by(external_id: github_user.id)
+    if identity.blank?
+      identity = integration.user_identities.create!(
+        user: user,
+        external_id: github_user.id,
+        external_username: github_user.login,
+        external_name: github_user.name,
+        external_email: github_user.email
+      )
+    elsif identity.user_id != user.id
+      raise MismatchWithExistingUser
+    else
+      # Update the existing identity with latest from the GitHub user profile
+      identity.update!(
+        external_username: github_user.login,
+        external_name: github_user.name,
+        external_email: github_user.email
+      )
+    end
+
+    identity
+  end
+
+  class InvalidCallbackState < StandardError
+  end
+
+  class NoAccessToken < StandardError
+  end
+
+  class MismatchWithExistingUser < StandardError
+  end
+end

--- a/app/services/provider_identities_service.rb
+++ b/app/services/provider_identities_service.rb
@@ -1,0 +1,11 @@
+module ProviderIdentitiesService
+  class << self
+    PROVIDERS = %w[
+      git_hub
+    ].freeze
+
+    def requires_identity?(provider_id)
+      PROVIDERS.include? provider_id
+    end
+  end
+end

--- a/app/services/resource_types_service.rb
+++ b/app/services/resource_types_service.rb
@@ -1,4 +1,4 @@
-class ResourceTypesService
+module ResourceTypesService
   class UnknownResourceType < StandardError
     attr_reader :id
 
@@ -63,6 +63,10 @@ class ResourceTypesService
 
     def for_provider(provider_id)
       all.find { |e| e[:providers].include? provider_id }
+    end
+
+    def for_integration(integration)
+      for_provider integration.provider_id
     end
 
     def integrations_for(id)

--- a/app/views/application/_sidebar-content.html.erb
+++ b/app/views/application/_sidebar-content.html.erb
@@ -17,6 +17,12 @@
 <hr />
 
 <h6 class="sidebar-heading">
+  <%= nav_item 'Access', me_access_path %>
+</h6>
+
+<hr />
+
+<h6 class="sidebar-heading">
   <%= nav_item 'Users', users_path %>
 </h6>
 

--- a/app/views/application/forms/_json_schema_field.html.erb
+++ b/app/views/application/forms/_json_schema_field.html.erb
@@ -16,6 +16,16 @@
       },
       { class: 'selectpicker' }
   %>
+<%- when 'integer'  %>
+  <%=
+    form.number_field name,
+      value: current_value,
+      required: is_required,
+      label: label_with_tooltip(
+        config_field_title(name, property_spec),
+        property_spec['description']
+      )
+  %>
 <%- else -%>
   <%=
     form.text_field name,

--- a/app/views/integrations/_global_credentials.html.erb
+++ b/app/views/integrations/_global_credentials.html.erb
@@ -1,0 +1,36 @@
+<% credentials = global_credentials_for integration %>
+<% if credentials.present? %>
+  <div class="<%= container_css_class if local_assigns.key? :container_css_class -%>">
+    <% panel_id = "credentials-panel-#{SecureRandom.hex(10)}" %>
+    <%=
+      tag.a(
+        href: '#',
+        data: {
+          toggle: 'collapse',
+          target: "##{panel_id}"
+        },
+        aria: {
+          controls: panel_id
+        }
+      ) do
+    %>
+      <%= icon 'key' %>
+      Robot access
+      <%= icon 'caret-down', css_class: 'ml-1' %>
+    <% end %>
+
+    <%=
+      tag.div(
+        id: panel_id,
+        class: 'collapse'
+      ) do
+    %>
+      <dl class="mt-2 card p-3 bg-light overflow-auto">
+        <% credentials.each do |(k, v)| %>
+          <dt><%= k -%></dt>
+          <dd class="text-wrap text-break"><%= v -%></dd>
+        <% end %>
+      </dl>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/me/access/show.html.erb
+++ b/app/views/me/access/show.html.erb
@@ -1,0 +1,113 @@
+<h1>Access</h1>
+
+<section class="my-access">
+  <% @groups.each do |group| %>
+    <div class="integrations-group py-2">
+      <h3 class="my-3">
+        <%= resource_icon group[:id] %>
+        <%= group[:name] %>
+      </h3>
+
+      <% if group[:entries].empty? %>
+        <p class="lead none-text">
+          No integrations are currently available for this resource type - a hub admin can set up a new integration if required.
+        </p>
+      <% else %>
+        <% group[:entries].each do |entry| %>
+          <% integration = entry[:integration] %>
+          <% identity = entry[:identity] %>
+          <% requires_identity = ProviderIdentitiesService.requires_identity? integration.provider_id %>
+          <% global_credentials = global_credentials_for integration %>
+
+          <div class="card shadow-sm mb-4">
+            <div class="card-header">
+              <strong>
+                <%= integration.name %>
+              </strong>
+            </div>
+            <ul class="list-group list-group-flush">
+              <li class="list-group-item">
+                <% if requires_identity %>
+                  <% if identity.present? %>
+                    <p>
+                      <%= icon 'check-circle', css_class: 'green' %>
+                      Connected
+                    </p>
+
+                    <div class="card p-2 bg-light">
+                      <dl class="row mb-0">
+                        <% data = identity.external_info %>
+                        <% data.each do |(k, v)| %>
+                          <dt class="col-sm-3"><%= k -%></dt>
+                          <dd class="col-sm-9"><%= v -%></dd>
+                        <% end %>
+                      </dl>
+
+                      <div>
+                        <%=
+                          link_to(
+                            'Disconnect',
+                            me_identity_path(integration_id: integration.id),
+                            method: :delete,
+                            class: 'btn btn-primary float-right ml-4',
+                            role: 'button',
+                            data: {
+                              confirm: 'Are you sure you want to disconnect your GitHub identity from this integration? This will remove you from any relevant teams within the org, so you may lose access to repositories.',
+                              title: "Disconnect GitHub identity for this integration and lose access",
+                              verify: 'yes',
+                              verify_text: "Type 'yes' to confirm"
+                            }
+                          )
+                        %>
+                      </div>
+                    </div>
+                  <% else %>
+                    <p class="mb-0">
+                      <%- case integration.provider_id -%>
+                      <%- when 'git_hub' -%>
+                        <%=
+                          link_to(
+                            'Connect your GitHub identity',
+                            me_identity_flow_git_hub_start_path(integration_id: integration.id),
+                            class: 'btn btn-primary float-right ml-4',
+                            role: 'button'
+                          )
+                        %>
+                      <%- end -%>
+
+                      <%= icon 'exclamation-triangle', css_class: 'yellow' %>
+
+                      <span>
+                        Not connected
+                      </span>
+                    </p>
+                  <% end %>
+                <% else %>
+                  <p class="mb-0">
+                    <%= icon 'info-circle', css_class: 'light-gray' %>
+                    The hub doesn't manage personal access for this integration – you may need to speak to your admin to give you access.
+                  </p>
+                <% end %>
+              </li>
+              <li class="list-group-item">
+                <% if global_credentials.present? %>
+                  <%=
+                    render partial: 'integrations/global_credentials',
+                      locals: {
+                        integration: integration
+                      }
+                  %>
+                <% else %>
+                  <p class="mb-0">
+                    <%= icon 'info-circle', css_class: 'light-gray' %>
+                    No robot access available for this resource.
+                  </p>
+                <% end %>
+              </li>
+            </ul>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/resources/_list-item.html.erb
+++ b/app/views/resources/_list-item.html.erb
@@ -48,42 +48,13 @@
       <%- end -%>
     </div>
 
-    <% credentials = global_credentials_for resource %>
-    <% if credentials.present? %>
-      <div class="indented mt-3">
-        <% panel_id = "credentials-panel-#{resource.id}" %>
-        <%=
-          tag.a(
-            href: '#',
-            data: {
-              toggle: 'collapse',
-              target: "##{panel_id}"
-            },
-            aria: {
-              controls: panel_id
-            }
-          ) do
-        %>
-          <%= icon 'key' %>
-          Credentials
-          <%= icon 'caret-down', css_class: 'ml-1' %>
-        <% end %>
-
-        <%=
-          tag.div(
-            id: panel_id,
-            class: 'collapse'
-          ) do
-        %>
-          <dl class="mt-2 card p-3 bg-light overflow-auto">
-            <% credentials.each do |(k, v)| %>
-              <dt><%= k -%></dt>
-              <dd class="text-wrap text-break"><%= v -%></dd>
-            <% end %>
-          </dl>
-        <% end %>
-      </div>
-    <% end %>
+    <%=
+      render partial: 'integrations/global_credentials',
+        locals: {
+          integration: resource.integration,
+          container_css_class: 'indented mt-3'
+        }
+    %>
 
     <% grouped_resources = group_resources_by_resource_type resource.children %>
     <% grouped_resources.each do |group| %>

--- a/app/webpack/stylesheets/application.scss
+++ b/app/webpack/stylesheets/application.scss
@@ -90,3 +90,19 @@ label.required:after {
     width: 186px;
   }
 }
+
+.red {
+  color: $red;
+}
+
+.yellow {
+  color: $yellow;
+}
+
+.green {
+  color: $green;
+}
+
+.light-gray {
+  color: $gray-500;
+}

--- a/app/workers/handle_identity_created_worker.rb
+++ b/app/workers/handle_identity_created_worker.rb
@@ -1,0 +1,18 @@
+class HandleIdentityCreatedWorker
+  include Sidekiq::Worker
+
+  def perform(identity_id)
+    identity = Identity.find_by id: identity_id
+
+    return if identity.nil?
+
+    integration = identity.integration
+    config = integration.config
+
+    case integration.provider_id
+    when 'git_hub'
+      agent = AgentsService.get integration.provider_id, config
+      agent.add_user_to_team config['all_team_id'], identity.external_username
+    end
+  end
+end

--- a/app/workers/handle_identity_deleted_worker.rb
+++ b/app/workers/handle_identity_deleted_worker.rb
@@ -1,0 +1,17 @@
+class HandleIdentityDeletedWorker
+  include Sidekiq::Worker
+
+  def perform(integration_id, external_info)
+    integration = Integration.find_by id: integration_id
+
+    return if integration.nil?
+
+    config = integration.config
+
+    case integration.provider_id
+    when 'git_hub'
+      agent = AgentsService.get integration.provider_id, config
+      agent.remove_user_from_team config['all_team_id'], external_info['Username']
+    end
+  end
+end

--- a/app/workers/resources/base_worker.rb
+++ b/app/workers/resources/base_worker.rb
@@ -1,63 +1,6 @@
-# rubocop:disable Metrics/ClassLength
 module Resources
   class BaseWorker
     include Sidekiq::Worker
-
-    AGENT_INITIALISERS = {
-      'git_hub' => lambda do |config|
-        GitHubAgent.new(
-          app_id: config['app_id'],
-          app_private_key: config['app_private_key'],
-          app_installation_id: config['app_installation_id'],
-          org: config['org']
-        )
-      end,
-      'ecr' => lambda do |config|
-        ECRAgent.new(
-          agent_base_url: Rails.configuration.agents.ecr.base_url,
-          agent_token: Rails.configuration.agents.ecr.token,
-          org: config['org'],
-          access_id: config['access_id'],
-          access_token: config['access_token'],
-          region: config['region'],
-          account: config['account'],
-          global_robot_name: config['global_robot_name']
-        )
-      end,
-      'quay' => lambda do |config|
-        QuayAgent.new(
-          agent_base_url: Rails.configuration.agents.quay.base_url,
-          agent_token: Rails.configuration.agents.quay.token,
-          quay_access_token: config['api_access_token'],
-          org: config['org'],
-          global_robot_name: config['global_robot_name']
-        )
-      end,
-      'kubernetes' => lambda do |config|
-        KubernetesAgent.new(
-          agent_base_url: Rails.configuration.agents.kubernetes.base_url,
-          agent_token: Rails.configuration.agents.kubernetes.token,
-          kube_api_url: config['api_url'],
-          kube_ca_cert: config['ca_cert'],
-          kube_token: config['token'],
-          global_service_account_name: config['global_service_account_name']
-        )
-      end,
-      'grafana' => lambda do |config|
-        GrafanaAgent.new(
-          agent_base_url: Rails.configuration.agents.grafana.base_url,
-          agent_token: Rails.configuration.agents.grafana.token,
-          grafana_url: config['url'],
-          grafana_api_key: config['api_key'],
-          grafana_ca_cert: config['ca_cert']
-        )
-      end,
-      'loki' => lambda do |config|
-        LokiAgent.new(
-          grafana_url: config['grafana_url']
-        )
-      end
-    }.freeze
 
     def perform(resource_id)
       with_resource(resource_id) do |resource|
@@ -101,9 +44,7 @@ module Resources
     end
 
     def with_agent(integration, config)
-      agent_initialiser = AGENT_INITIALISERS[integration.provider_id]
-
-      agent = agent_initialiser&.call config
+      agent = AgentsService.get integration.provider_id, config
 
       if agent
         yield agent
@@ -127,4 +68,3 @@ module Resources
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/workers/resources/request_create_worker.rb
+++ b/app/workers/resources/request_create_worker.rb
@@ -3,9 +3,12 @@ module Resources
     HANDLERS = {
       'Resources::CodeRepo' => {
         'git_hub' => lambda do |resource, agent, config|
+          all_team_id = config['all_team_id']
           enforce_best_practices = config['enforce_best_practices']
 
-          result = agent.create_repository resource.name, best_practices: enforce_best_practices
+          result = agent.create_repository resource.name,
+            team_id: all_team_id,
+            best_practices: enforce_best_practices
 
           resource.private = result.private
           resource.full_name = result.full_name

--- a/config/initializers/app_config.rb
+++ b/config/initializers/app_config.rb
@@ -1,0 +1,1 @@
+Rails.application.config.base_url = ENV.fetch('BASE_URL') { raise 'BASE_URL missing from env' }

--- a/config/initializers/encryptor.rb
+++ b/config/initializers/encryptor.rb
@@ -1,0 +1,1 @@
+ENCRYPTOR ||= EncryptorService.new(Rails.application.secrets.secret_key_base)

--- a/config/providers.yml
+++ b/config/providers.yml
@@ -9,7 +9,7 @@
       app_id:
         title: Your GitHub App ID
         description: "The app ID for the [GitHub App](https://developer.github.com/apps/about-apps/) you have set up."
-        type: string
+        type: integer
       app_private_key:
         title: Your GitHub App private key
         description: "A private key for the [GitHub App](https://developer.github.com/apps/about-apps/) you have set up."
@@ -18,6 +18,7 @@
       app_installation_id:
         title: Your GitHub App installation on your org
         description: "The specific installation of your GitHub App within your GitHub organisation."
+        type: integer
         type: string
       enforce_best_practices:
         title: Enforce best practices

--- a/config/providers.yml
+++ b/config/providers.yml
@@ -6,6 +6,10 @@
         title: Your GitHub organisation
         description: "The organisation on GitHub to manage repos for. This should be the 'login' value as specified in https://developer.github.com/v3/orgs/."
         type: string
+      all_team_id:
+        title: Team ID for all users
+        description: "The numeric ID of the org's main team in which to place all hub users in and grant repos admin access to. This should be the 'id' value from https://developer.github.com/v3/teams/#list-teams – see also http://fabian-kostadinov.github.io/2015/01/16/how-to-find-a-github-team-id/"
+        type: integer
       app_id:
         title: Your GitHub App ID
         description: "The app ID for the [GitHub App](https://developer.github.com/apps/about-apps/) you have set up."
@@ -19,7 +23,15 @@
         title: Your GitHub App installation on your org
         description: "The specific installation of your GitHub App within your GitHub organisation."
         type: integer
+      app_client_id:
+        title: Your GitHub App's Client ID
+        description: "The Client ID from the App's settings page."
         type: string
+      app_client_secret:
+        title: Your GitHub App's Client Secret
+        description: "The Client Secret from the App's settings page."
+        type: string
+        masked: true
       enforce_best_practices:
         title: Enforce best practices
         description: "If enabled, all repositories created will have their master branches protected for all users (including admins) with: require pull request reviews before merging and require branches to be up to date before merging."
@@ -27,9 +39,12 @@
         overridable: true
     required:
       - org
+      - all_team_id
       - app_id
       - app_private_key
       - app_installation_id
+      - app_client_id
+      - app_client_secret
 
 - id: ecr
   name: ECR

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 require 'sidekiq/web'
 
+# rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
   namespace :admin do
     resources :integrations, except: %i[show destroy]
@@ -21,6 +22,28 @@ Rails.application.routes.draw do
     resource :role, only: %i[update], controller: 'users', action: :update_role
   end
 
+  namespace :me do
+    resource :access, only: %i[show], controller: 'access'
+
+    delete '/identities/:integration_id',
+      to: 'identities#destroy',
+      as: 'identity'
+
+    scope '/identity_flows/:integration_id' do
+      # GitHub
+      scope '/git_hub' do
+        get :start,
+          to: 'identity_flows#git_hub_start',
+          as: 'identity_flow_git_hub_start'
+
+        get :callback,
+          to: 'identity_flows#git_hub_callback',
+          as: 'identity_flow_git_hub_callback'
+      end
+    end
+  end
+
   root to: 'home#show'
   mount Sidekiq::Web => '/sidekiq'
 end
+# rubocop:enable Metrics/BlockLength

--- a/db/migrate/20190614115742_create_identities.rb
+++ b/db/migrate/20190614115742_create_identities.rb
@@ -1,0 +1,17 @@
+class CreateIdentities < ActiveRecord::Migration[5.2]
+  def change
+    create_table :identities, id: :uuid do |t|
+      t.belongs_to :user, null: false, type: :uuid
+      t.belongs_to :integration, null: false, type: :uuid
+      t.string :external_id, null: false
+      t.string :external_username
+      t.string :external_name
+      t.string :external_email
+
+      t.timestamps
+
+      t.index %i[user_id integration_id], unique: true
+      t.index %i[integration_id external_id], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_21_123220) do
+ActiveRecord::Schema.define(version: 2019_06_14_115742) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -49,6 +49,21 @@ ActiveRecord::Schema.define(version: 2019_05_21_123220) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["slug"], name: "index_hash_records_on_slug", unique: true
+  end
+
+  create_table "identities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.uuid "integration_id", null: false
+    t.string "external_id", null: false
+    t.string "external_username"
+    t.string "external_name"
+    t.string "external_email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["integration_id", "external_id"], name: "index_identities_on_integration_id_and_external_id", unique: true
+    t.index ["integration_id"], name: "index_identities_on_integration_id"
+    t.index ["user_id", "integration_id"], name: "index_identities_on_user_id_and_integration_id", unique: true
+    t.index ["user_id"], name: "index_identities_on_user_id"
   end
 
   create_table "integration_overrides", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       - --enable-logging=true
       - --enable-json-logging=false
       - --verbose=false
+      - --resources=uri=/me/identity_flows/{integrationID:\w+}/git_hub/callback|white-listed=true|methods=GET
       - --resources=uri=/*
     ports:
       - 3000:3000

--- a/spec/factories/identities.rb
+++ b/spec/factories/identities.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :identity do
+    user
+    sequence :external_id do |n|
+      "id-#{n}"
+    end
+
+    # NOTE: this factory will not produce a valid model object out of the box
+    # - you will need to set the `integration` association when using it.
+  end
+end

--- a/spec/integration/resources/code_repos/git_hub_code_repos_integration_spec.rb
+++ b/spec/integration/resources/code_repos/git_hub_code_repos_integration_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe 'Code Repos - GitHub' do
 
     let :integration_config do
       {
-        'app_id' => 'foo_app',
-        'app_private_key' => 'foo_private_key',
-        'app_installation_id' => 'foo_installation',
         'org' => 'foo',
+        'all_team_id' => 1000,
         'app_id' => 12_345,
         'app_private_key' => 'foo_private_key',
         'app_installation_id' => 1_010_101,
+        'app_client_id' => 'app client id',
+        'app_client_secret' => 'supersecret',
         'enforce_best_practices' => true
       }
     end
@@ -23,7 +23,12 @@ RSpec.describe 'Code Repos - GitHub' do
 
     let(:agent_class) { GitHubAgent }
     let :agent_initializer_params do
-      integration_config.symbolize_keys.except(:enforce_best_practices)
+      integration_config.symbolize_keys.except(
+        :all_team_id,
+        :enforce_best_practices,
+        :app_client_id,
+        :app_client_secret
+      )
     end
 
     let :agent_create_response do
@@ -37,7 +42,7 @@ RSpec.describe 'Code Repos - GitHub' do
     let :agent_create_method_call_success do
       lambda do |agent, resource|
         expect(agent).to receive(:create_repository)
-          .with(resource.name, best_practices: true)
+          .with(resource.name, team_id: 1000, best_practices: true)
           .and_return(agent_create_response)
       end
     end
@@ -54,7 +59,7 @@ RSpec.describe 'Code Repos - GitHub' do
     let :agent_create_method_call_error do
       lambda do |agent, resource|
         expect(agent).to receive(:create_repository)
-          .with(resource.name, best_practices: true)
+          .with(resource.name, team_id: 1000, best_practices: true)
           .and_raise('Something broked')
       end
     end

--- a/spec/integration/resources/code_repos/git_hub_code_repos_integration_spec.rb
+++ b/spec/integration/resources/code_repos/git_hub_code_repos_integration_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe 'Code Repos - GitHub' do
         'app_private_key' => 'foo_private_key',
         'app_installation_id' => 'foo_installation',
         'org' => 'foo',
+        'app_id' => 12_345,
+        'app_private_key' => 'foo_private_key',
+        'app_installation_id' => 1_010_101,
         'enforce_best_practices' => true
       }
     end

--- a/spec/integration/resources/code_repos/git_hub_code_repos_overriden_config_integration_spec.rb
+++ b/spec/integration/resources/code_repos/git_hub_code_repos_overriden_config_integration_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe 'Code Repo - GitHub - with overriden config option' do
       'app_private_key' => 'foo_private_key',
       'app_installation_id' => 'foo_installation',
       'org' => 'foo',
+      'app_id' => 12_345,
+      'app_private_key' => 'foo_private_key',
+      'app_installation_id' => 1_010_101,
       'enforce_best_practices' => true
     }
   end

--- a/spec/integration/resources/code_repos/git_hub_code_repos_overriden_config_integration_spec.rb
+++ b/spec/integration/resources/code_repos/git_hub_code_repos_overriden_config_integration_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe 'Code Repo - GitHub - with overriden config option' do
 
   let :integration_config do
     {
-      'app_id' => 'foo_app',
-      'app_private_key' => 'foo_private_key',
-      'app_installation_id' => 'foo_installation',
       'org' => 'foo',
+      'all_team_id' => 1000,
       'app_id' => 12_345,
       'app_private_key' => 'foo_private_key',
       'app_installation_id' => 1_010_101,
+      'app_client_id' => 'app client id',
+      'app_client_secret' => 'supersecret',
       'enforce_best_practices' => true
     }
   end
@@ -42,7 +42,12 @@ RSpec.describe 'Code Repo - GitHub - with overriden config option' do
   let(:agent_class) { GitHubAgent }
 
   let :agent_initializer_params do
-    integration_config.symbolize_keys.except(:enforce_best_practices)
+    integration_config.symbolize_keys.except(
+      :all_team_id,
+      :enforce_best_practices,
+      :app_client_id,
+      :app_client_secret
+    )
   end
 
   let :agent do
@@ -69,7 +74,7 @@ RSpec.describe 'Code Repo - GitHub - with overriden config option' do
   describe 'request create' do
     it 'agent should receive the overriden config option' do
       expect(agent).to receive(:create_repository)
-        .with(resource.name, best_practices: !integration_config['enforce_best_practices'])
+        .with(resource.name, team_id: 1000, best_practices: !integration_config['enforce_best_practices'])
         .and_return(agent_create_response)
 
       expect do

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Identity, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/me/access_spec.rb
+++ b/spec/requests/me/access_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'Me - Access', type: :request do
+  include_context 'time helpers'
+
+  describe 'show - GET /me/access' do
+    it_behaves_like 'unauthenticated not allowed' do
+      before do
+        get me_access_path
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+      it 'loads the me access show page' do
+        get me_access_path
+        expect(response).to be_successful
+        expect(response).to render_template(:show)
+        expect(assigns(:groups)).not_to be nil
+      end
+    end
+  end
+end

--- a/spec/requests/me/identities_spec.rb
+++ b/spec/requests/me/identities_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe 'Me - Identities', type: :request do
+  include_context 'time helpers'
+
+  describe 'destroy - DELETE /me/identities/:integration_id' do
+    let :integration do
+      create_mocked_integration
+    end
+
+    it_behaves_like 'unauthenticated not allowed' do
+      before do
+        delete me_identity_path(integration_id: integration.id)
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+      let!(:other_user) { create :user }
+      let! :other_identity do
+        create :identity, user: other_user, integration: integration
+      end
+
+      context 'for an integration that doesn\'t exist' do
+        it 'throws an error' do
+          expect do
+            delete me_identity_path(integration_id: 'does-not-exist')
+          end.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      context 'when the user doesn\'t have an identity for the integration' do
+        it 'throws an error' do
+          original_identity_count = Identity.count
+
+          expect do
+            delete me_identity_path(integration_id: integration.id)
+          end.to raise_error(ActiveRecord::RecordNotFound)
+
+          expect(Identity.count).to eq original_identity_count
+        end
+      end
+
+      context 'when the user does have an identity for the integration' do
+        let! :identity do
+          create :identity, user: current_user, integration: integration
+        end
+
+        it 'deletes the user\'s identity for the specified integration' do
+          expect do
+            delete me_identity_path(integration_id: integration.id)
+          end.to change(Identity, :count).by(-1)
+
+          expect(response).to redirect_to(me_access_path)
+
+          expect(Identity.exists?(id: identity.id)).to be false
+          expect(Identity.exists?(id: other_identity.id)).to be true
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/me/identity_flows_spec.rb
+++ b/spec/requests/me/identity_flows_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+RSpec.describe 'Me - Identity Flows', type: :request do
+  include_context 'time helpers'
+
+  describe 'GitHub identity flows' do
+    let :git_hub_identity_service do
+      instance_double 'GitHubIdentityService'
+    end
+
+    before do
+      allow(GitHubIdentityService).to receive(:new)
+        .and_return(git_hub_identity_service)
+    end
+
+    describe 'git_hub_start - GET /me/identity_flows/:integration_id/git_hub/start' do
+      let :integration do
+        create_mocked_integration
+      end
+
+      it_behaves_like 'unauthenticated not allowed' do
+        before do
+          get me_identity_flow_git_hub_start_path(integration_id: integration.id)
+        end
+      end
+
+      it_behaves_like 'authenticated' do
+        let :base_url do
+          'http://localhost'
+        end
+
+        let :callback_url do
+          URI.join(
+            base_url,
+            "/me/identity_flows/#{integration.id}/git_hub/callback"
+          ).to_s
+        end
+
+        before do
+          allow(Rails.configuration).to receive(:base_url)
+            .and_return(base_url)
+        end
+
+        it 'redirects to the GitHub OAuth authorize endpoint with an appropriate callback_url' do
+          git_hub_auth_url = 'git_hub_auth_url'
+          expect(git_hub_identity_service).to receive(:authorize_url)
+            .with(current_user, callback_url)
+            .and_return(git_hub_auth_url)
+
+          get me_identity_flow_git_hub_start_path(integration_id: integration.id)
+
+          expect(response).to redirect_to(git_hub_auth_url)
+        end
+      end
+    end
+
+    describe 'git_hub_callback - GET /me/identity_flows/:integration_id/git_hub/callback' do
+      let :integration do
+        create_mocked_integration
+      end
+
+      # Note: not an authenticated endpoint
+
+      it 'handles a missing "code" param' do
+        expect(git_hub_identity_service).to receive(:connect_identity).never
+
+        get me_identity_flow_git_hub_callback_path(integration_id: integration.id, state: 'foo')
+
+        expect(response).to redirect_to(root_path)
+      end
+
+      it 'handles a missing "state" param' do
+        expect(git_hub_identity_service).to receive(:connect_identity).never
+
+        get me_identity_flow_git_hub_callback_path(integration_id: integration.id, code: 'foo')
+
+        expect(response).to redirect_to(root_path)
+      end
+
+      context 'with an invalid integration' do
+        let :invalid_integration do
+          create_mocked_integration provider_id: 'kubernetes'
+        end
+
+        it 'renders an error page' do
+          expect(git_hub_identity_service).to receive(:connect_identity).never
+
+          get me_identity_flow_git_hub_callback_path(integration_id: invalid_integration.id, code: 'foo', state: 'bar')
+
+          expect(response).to have_http_status(422)
+        end
+      end
+
+      context 'the GitHubIdentityService throws a NoAccessToken error' do
+        let(:code) { 'code' }
+        let(:state) { 'state' }
+
+        before do
+          expect(git_hub_identity_service).to receive(:connect_identity)
+            .with(integration, code, state)
+            .and_raise(GitHubIdentityService::NoAccessToken)
+        end
+
+        it 'handles the error and responds with an HTTP 403' do
+          get me_identity_flow_git_hub_callback_path(integration_id: integration.id, code: code, state: state)
+          expect(response).to have_http_status(403)
+        end
+      end
+    end
+  end
+end

--- a/spec/routing/me/access_routing_spec.rb
+++ b/spec/routing/me/access_routing_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Me::AccessController, type: :routing do
+  describe 'routing' do
+    it 'routes to #show' do
+      expect(get: '/me/access').to route_to('me/access#show')
+    end
+  end
+end

--- a/spec/routing/me/identities_routing_spec.rb
+++ b/spec/routing/me/identities_routing_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Me::IdentitiesController, type: :routing do
+  describe 'routing' do
+    it 'routes to #destroy' do
+      expect(delete: '/me/identities/1').to route_to('me/identities#destroy', integration_id: '1')
+    end
+  end
+end

--- a/spec/routing/me/identity_flows_routing_spec.rb
+++ b/spec/routing/me/identity_flows_routing_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe Me::IdentityFlowsController, type: :routing do
+  describe 'routing' do
+    describe 'GitHub identity flow routes' do
+      it 'routes to #git_hub_start' do
+        expect(get: '/me/identity_flows/1/git_hub/start').to route_to('me/identity_flows#git_hub_start', integration_id: '1')
+      end
+
+      it 'routes to #git_hub_callback' do
+        expect(get: '/me/identity_flows/1/git_hub/callback').to route_to('me/identity_flows#git_hub_callback', integration_id: '1')
+      end
+    end
+  end
+end

--- a/spec/services/encryptor_service_spec.rb
+++ b/spec/services/encryptor_service_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe EncryptorService, type: :service do
+  let(:secret_key_base) { SecureRandom.base64(100) }
+  let(:string) { 'my secret string' }
+
+  before do
+    @service = EncryptorService.new(secret_key_base)
+  end
+
+  it 'should encrypt and decrypt a string as expected' do
+    expect(@service.decrypt(@service.encrypt(string))).to eq string
+  end
+
+  it 'should be tied to that specific secret key' do
+    other_secret_key_base = SecureRandom.base64(100)
+    other_service = EncryptorService.new(other_secret_key_base)
+
+    expect(other_service.decrypt(other_service.encrypt(string))).to eq string
+    expect(@service.decrypt(other_service.encrypt(string))).to eq nil
+    expect(other_service.decrypt(@service.encrypt(string))).to eq nil
+  end
+end

--- a/spec/workers/handle_identity_created_worker_spec.rb
+++ b/spec/workers/handle_identity_created_worker_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+RSpec.describe HandleIdentityCreatedWorker, type: :worker do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/workers/handle_identity_deleted_worker_spec.rb
+++ b/spec/workers/handle_identity_deleted_worker_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+RSpec.describe HandleIdentityDeletedWorker, type: :worker do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Closes #167 

- A global/all GitHub team ID can now be specified for a GitHub integration – all code repos will be assigned this team (with admin permissions).
- Users can now connect (and disconnect) their GitHub identity (via a GitHub OAuth flow) to a GitHub integration, after which they will be added to the team ID for that integration.

---

NOTE: this includes some breaking changes:

- A new `BASE_URL` needs to be configured in the env to start up the hub server.
- The auth proxy will need to add the new GitHub OAuth callback endpoint to the allowlist.
- For any existing GitHub integrations in a hub instance…
  - … a new GitHub team ID will need to be provided
  - … the client ID and secret for the GitHub App is now needed too
  - … permissions for the GitHub App will need to be updated
    - --> Read & write on "Organization members"

---

TODO:

- [x] Thorough manual testing (end-to-end)
- [x] More specs for new bits