### PR TITLE
Store the user's GitHub access token when they connect their GitHub identity

### DIFF
--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -13,6 +13,11 @@ class Identity < ApplicationRecord
     presence: true,
     uniqueness: { scope: :integration_id }
 
+  crypt_keeper :access_token,
+    encryptor: :active_support,
+    key: Rails.application.secrets.secret_key_base,
+    salt: Rails.application.secrets.secret_salt
+
   after_create_commit :trigger_created_worker
   after_destroy_commit :trigger_deleted_worker
 

--- a/app/services/git_hub_identity_service.rb
+++ b/app/services/git_hub_identity_service.rb
@@ -36,7 +36,8 @@ class GitHubIdentityService
         external_id: github_user.id,
         external_username: github_user.login,
         external_name: github_user.name,
-        external_email: github_user.email
+        external_email: github_user.email,
+        access_token: access_token
       )
     elsif identity.user_id != user.id
       raise MismatchWithExistingUser
@@ -45,7 +46,8 @@ class GitHubIdentityService
       identity.update!(
         external_username: github_user.login,
         external_name: github_user.name,
-        external_email: github_user.email
+        external_email: github_user.email,
+        access_token: access_token
       )
     end
 

--- a/db/migrate/20190704143604_add_access_token_to_identities.rb
+++ b/db/migrate/20190704143604_add_access_token_to_identities.rb
@@ -1,0 +1,5 @@
+class AddAccessTokenToIdentities < ActiveRecord::Migration[5.2]
+  def change
+    add_column :identities, :access_token, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_14_115742) do
+ActiveRecord::Schema.define(version: 2019_07_04_143604) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -60,6 +60,7 @@ ActiveRecord::Schema.define(version: 2019_06_14_115742) do
     t.string "external_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "access_token"
     t.index ["integration_id", "external_id"], name: "index_identities_on_integration_id_and_external_id", unique: true
     t.index ["integration_id"], name: "index_identities_on_integration_id"
     t.index ["user_id", "integration_id"], name: "index_identities_on_user_id_and_integration_id", unique: true


### PR DESCRIPTION
This is required for [User-to-Server API requests to the GitHub API](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#user-to-server-requests).