### PR TITLE
Ability to configure and use template repos for GitHub code repo creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'faraday', '~> 0.15.4'
 gem 'faraday_middleware', '~> 0.13.1'
 gem 'typhoeus', '~> 1.3', '>= 1.3.1'
 gem 'closure_tree', '~> 7.0'
+gem 'wait', '~> 0.5.3'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,6 +249,7 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.5.0)
+    wait (0.5.3)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -308,6 +309,7 @@ DEPENDENCIES
   turbolinks (~> 5.2)
   typhoeus (~> 1.3, >= 1.3.1)
   tzinfo-data
+  wait (~> 0.5.3)
   web-console (>= 3.3.0)
   webpacker (~> 4.0, >= 4.0.7)
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -10,7 +10,7 @@ class ProjectsController < ApplicationController
       next nil unless rt[:top_level]
 
       integrations = ResourceTypesService.integrations_for rt[:id]
-      resources = @project.send rt[:id].tableize
+      resources = @project.send(rt[:id].tableize).order(:name)
       rt.merge integrations: integrations, resources: resources
     end.compact
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,7 +54,7 @@ module ApplicationHelper
     raw(
       [
         label,
-        icon_with_tooltip(tooltip_text)
+        (icon_with_tooltip(tooltip_text) if tooltip_text.present?)
       ].join(' ')
     )
     # rubocop:enable Rails/OutputSafety

--- a/app/lib/json_schema_helpers.rb
+++ b/app/lib/json_schema_helpers.rb
@@ -5,10 +5,19 @@ module JsonSchemaHelpers
     return data if data.blank?
 
     spec.properties.each do |(name, property_spec)|
-      if property_spec.type.include?('boolean')
-        data[name] = ActiveRecord::Type::Boolean.new.cast(data[name])
-      elsif property_spec.type.include?('integer')
-        data[name] = data[name].to_i
+      case data[name]
+      when Hash
+        data[name] = ensure_data_types data[name], property_spec
+      when Array
+        data[name] = data[name].map do |item|
+          ensure_data_types item, property_spec['items']
+        end
+      else
+        if property_spec.type.include?('boolean')
+          data[name] = ActiveRecord::Type::Boolean.new.cast(data[name])
+        elsif property_spec.type.include?('integer')
+          data[name] = data[name].to_i
+        end
       end
     end
 

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -16,6 +16,11 @@ class Resource < ApplicationRecord
     -> { readonly },
     inverse_of: :resources
 
+  belongs_to :requested_by,
+    -> { readonly },
+    class_name: 'User',
+    inverse_of: false
+
   enum status: {
     pending: 'pending',
     active: 'active',
@@ -30,7 +35,7 @@ class Resource < ApplicationRecord
     uniqueness: { scope: :integration_id },
     readonly: true
 
-  attr_readonly :project_id, :integration_id
+  attr_readonly :project_id, :integration_id, :requested_by_id
 
   default_value_for :status, :pending
 

--- a/app/models/resources/code_repo.rb
+++ b/app/models/resources/code_repo.rb
@@ -4,5 +4,6 @@ module Resources
     attr_json :full_name, :string
     attr_json :url, :string
     attr_json :enforce_best_practices, :boolean, default: false
+    attr_json :template_url, :string
   end
 end

--- a/app/services/project_resources_bootstrap_service.rb
+++ b/app/services/project_resources_bootstrap_service.rb
@@ -19,7 +19,7 @@ class ProjectResourcesBootstrapService
     end.compact
   end
 
-  def bootstrap
+  def bootstrap(requested_by:)
     prepare_results = prepare_bootstrap
 
     return prepare_results if prepare_results.blank?
@@ -38,6 +38,7 @@ class ProjectResourcesBootstrapService
 
       resource = @project.send(i[:id].tableize).create!(
         integration: integration,
+        requested_by: requested_by,
         name: i[:resource][:name]
       )
 

--- a/app/services/providers_registry.rb
+++ b/app/services/providers_registry.rb
@@ -30,12 +30,15 @@ class ProvidersRegistry
     raise 'Provider IDs must be set and unique' if ids.size != data.size
 
     # For each provider `config_spec`:
+    # - Check any custom validations for each property spec
     # - Add certain assumed JSON Schema fields
     # - Validate that each is valid JSON Schema
     # - Store the JSON Schema object
     data.each do |p|
       id = p['id']
       config_spec = p['config_spec']
+
+      validate_property_specs config_spec['properties']
 
       config_spec['type'] = 'object'
       config_spec['additionalProperties'] = false
@@ -47,5 +50,29 @@ class ProvidersRegistry
       data.freeze,
       config_schemas.freeze
     ]
+  end
+
+  # Checks:
+  # - Only allow the `overridable` flag on top level properties of types
+  #   other than `array` or `object`
+  # - Only allow `array`s of `object`s
+  def validate_property_specs(properties)
+    properties.each do |(name, property_spec)|
+      type = property_spec['type']
+
+      has_overridable_flag = property_spec.key?('overridable')
+      array_or_object_type = %w[array object].include?(type)
+
+      if has_overridable_flag && array_or_object_type
+        raise [
+          "'overrideable' flag can only be used on top level properties -",
+          "property '#{name}' cannot have it"
+        ].join(' ')
+      end
+
+      if type == 'array' && property_spec['items']['type'] != 'object'
+        raise "Only arrays of objects are currently supported - property '#{name}' is an array of something else"
+      end
+    end
   end
 end

--- a/app/services/resource_provisioning_service.rb
+++ b/app/services/resource_provisioning_service.rb
@@ -34,6 +34,7 @@ class ResourceProvisioningService
     resource_class = resource_type[:class].constantize
     dependent_resource = resource_class.create!(
       integration: integrations.first,
+      requested_by: parent_resource.requested_by,
       parent: parent_resource,
       project: parent_resource.project,
       name: parent_resource.name

--- a/app/services/resources/create_git_hub_code_repo_service.rb
+++ b/app/services/resources/create_git_hub_code_repo_service.rb
@@ -1,0 +1,74 @@
+module Resources
+  class CreateGitHubCodeRepoService
+    IMPORT_WAIT_ATTEMPTS = 15
+    IMPORT_WAIT_CHECK_TIMEOUT = 30.seconds.to_i
+    IMPORT_WAIT_DELAY = 20.seconds.to_i
+    IMPORT_WAIT_FINISH_STATUSES = %w[
+      complete
+      auth_failed
+      error
+      detection_needs_auth
+      detection_found_nothing
+      detection_found_multiple
+    ].freeze
+
+    def initialize(agent)
+      @agent = agent
+    end
+
+    def call(resource, config)
+      all_team_id = config['all_team_id']
+
+      should_enforce_best_practices = config['enforce_best_practices']
+
+      should_auto_init = should_enforce_best_practices && resource.template_url.blank?
+
+      create_result = @agent.create_repository(
+        resource.name,
+        team_id: all_team_id,
+        auto_init: should_auto_init
+      )
+
+      resource.private = create_result.private
+      resource.full_name = create_result.full_name
+      resource.url = create_result.html_url
+      resource.enforce_best_practices = should_enforce_best_practices
+
+      import_from_template_if_needed resource
+
+      @agent.apply_best_practices(resource.full_name) if should_enforce_best_practices
+    end
+
+    private
+
+    def import_from_template_if_needed(resource)
+      return if resource.template_url.blank?
+
+      user_auth_token = resource
+        .requested_by
+        .identities
+        .find_by(integration_id: resource.integration_id)
+        &.access_token
+
+      result = @agent.import_from_template(
+        resource.full_name,
+        resource.template_url,
+        user_auth_token: user_auth_token
+      )
+
+      git_hub_client = result[:client]
+
+      wait = Wait.new(
+        attempts: IMPORT_WAIT_ATTEMPTS,
+        timeout: IMPORT_WAIT_CHECK_TIMEOUT,
+        delay: IMPORT_WAIT_DELAY,
+        debug: Rails.env.development?
+      )
+
+      wait.until do
+        result = git_hub_client.source_import_progress(resource.full_name)
+        IMPORT_WAIT_FINISH_STATUSES.include? result['status']
+      end
+    end
+  end
+end

--- a/app/views/admin/integrations/_card.html.erb
+++ b/app/views/admin/integrations/_card.html.erb
@@ -10,39 +10,16 @@
       <%= pluralize integration.resources.count, 'resource' %>
     </p>
 
-    <% config_spec['properties'].each do |(name, property_spec)| %>
-      <dl>
-        <dt>
-          <%= config_field_title name, property_spec %>
-          <%= icon_with_tooltip property_spec['description'] %>
-        </dt>
-        <dd>
-          <% value = integration.config[name] %>
-          <% if value.nil? || value == '' %>
-            <span class="none-text">
-              not set
-            </span>
-          <% else %>
-            <% if !property_spec['masked'] || unmask %>
-              <%= value -%>
-            <% else %>
-              <span class="text-muted font-weight-light">
-                hidden
-              </span>
-              <%=
-                link_to 'show all hidden',
-                  {
-                    expand: group[:id],
-                    anchor: integration.id,
-                    unmask: true
-                  },
-                  class: 'ml-3'
-              %>
-            <% end %>
-          <% end %>
-        </dd>
-      </dl>
-    <% end %>
+    <%=
+      render partial: 'config_fields',
+        locals: {
+          spec: config_spec,
+          data: integration.config,
+          group_id: group[:id],
+          integration_id: integration.id,
+          unmask: unmask
+        }
+    %>
   </div>
   <div class="card-footer">
     <%= link_to 'Edit', edit_admin_integration_path(integration), class: 'btn btn-primary' %>

--- a/app/views/admin/integrations/_config_fields.html.erb
+++ b/app/views/admin/integrations/_config_fields.html.erb
@@ -1,0 +1,73 @@
+<% spec['properties'].each do |(name, property_spec)| %>
+  <dl>
+    <dt>
+      <%= config_field_title name, property_spec %>
+      <%= icon_with_tooltip(property_spec['description']) if property_spec['description'].present? %>
+    </dt>
+    <dd>
+      <% value = data[name] %>
+
+      <% if value.blank? %>
+
+        <span class="none-text">
+          not set
+        </span>
+
+      <% else %>
+
+        <% if property_spec['type'] == 'array' %>
+
+          <% value.each do |item| %>
+            <div class="indented m-2">
+              <%=
+                render partial: 'config_fields',
+                  locals: {
+                    spec: property_spec['items'],
+                    data: item,
+                    group_id: group_id,
+                    integration_id: integration_id,
+                    unmask: unmask
+                  }
+              %>
+            </div>
+          <% end %>
+
+        <% elsif property_spec['type'] == 'object' %>
+
+          <div class="indented m-2">
+            <%=
+              render partial: 'config_fields',
+                locals: {
+                  spec: property_spec,
+                  data: value,
+                  group_id: group_id,
+                  integration_id: integration_id,
+                  unmask: unmask
+                }
+            %>
+          </div>
+
+        <% else %>
+
+          <% if !property_spec['masked'] || unmask %>
+            <%= value -%>
+          <% else %>
+            <span class="text-muted font-weight-light">
+              hidden
+            </span>
+            <%=
+              link_to 'show all hidden',
+                {
+                  expand: group_id,
+                  anchor: integration_id,
+                  unmask: true
+                },
+                class: 'ml-3'
+            %>
+          <% end %>
+
+        <% end %>
+      <% end %>
+    </dd>
+  </dl>
+<% end %>

--- a/app/views/admin/integrations/_form.html.erb
+++ b/app/views/admin/integrations/_form.html.erb
@@ -19,22 +19,15 @@
       Config
     </div>
     <div class="card-body">
-      <%= form.fields_for :config do |config_fields| %>
-        <% spec = integration.provider['config_spec'] %>
-        <% spec['properties'].each do |(name, property_spec)| %>
-          <%=
-            render partial: 'application/forms/json_schema_field',
-              locals: {
-                form: config_fields,
-                name: name,
-                property_spec: property_spec,
-                is_required: spec['required'].include?(name),
-                current_value: integration.config[name],
-                include_blank: false
-              }
-          %>
-        <% end %>
-      <% end %>
+      <%=
+        render partial: 'form_fields',
+          locals: {
+            form: form,
+            namespace: :config,
+            spec: integration.provider['config_spec'],
+            current: integration.config || {}
+          }
+      %>
     </div>
   </div>
 

--- a/app/views/admin/integrations/_form_fields.html.erb
+++ b/app/views/admin/integrations/_form_fields.html.erb
@@ -1,0 +1,82 @@
+<% is_array = local_assigns.fetch :is_array, false %>
+
+<% spec['properties'].each do |(name, property_spec)| %>
+  <% fields_for_options = is_array ? { index: nil } : {} %>
+  <%= form.fields_for namespace, fields_for_options do |fields_form| %>
+    <% if property_spec['type'] == 'array' %>
+
+      <div data-controller="form-nested-list">
+        <template data-target="form-nested-list.template">
+          <%=
+            render partial: 'form_fields_array_item',
+              locals: {
+                form: fields_form,
+                name: name,
+                property_spec: property_spec,
+                item: {}
+              }
+          %>
+        </template>
+
+        <h6>
+          <%=
+            label_with_tooltip(
+              config_field_title(name, property_spec),
+              property_spec['description']
+            )
+          %>
+        </h6>
+
+        <div>
+          <% Array(current[name]).each do |item| %>
+            <%=
+              render partial: 'form_fields_array_item',
+                locals: {
+                  form: fields_form,
+                  name: name,
+                  property_spec: property_spec,
+                  item: item || {}
+                }
+            %>
+          <% end %>
+
+          <div class="mb-3" data-target="form-nested-list.links">
+            <%= link_to "Add", "#", class: "btn btn-sm btn-outline-primary", data: { action: "click->form-nested-list#add" } %>
+          </div>
+        </div>
+      </div>
+
+    <% else %>
+
+      <% if property_spec['type'] == 'object' %>
+
+        <%=
+          render partial: 'form_fields_nested_object',
+            locals: {
+              form: fields_form,
+              name: name,
+              spec: property_spec,
+              current: current[name] || {},
+              is_array: false
+            }
+        %>
+
+      <% else %>
+
+        <%=
+          render partial: 'application/forms/json_schema_field',
+            locals: {
+              form: fields_form,
+              name: name,
+              property_spec: property_spec,
+              is_required: spec['required'].include?(name),
+              current_value: current[name],
+              include_blank: false
+            }
+        %>
+
+      <% end %>
+
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/admin/integrations/_form_fields_array_item.html.erb
+++ b/app/views/admin/integrations/_form_fields_array_item.html.erb
@@ -1,0 +1,14 @@
+<%=
+  render(
+    'form_fields_nested_object',
+    form: form,
+    name: name,
+    spec: property_spec['items'],
+    current: item,
+    is_array: true
+  ) do
+%>
+  <div>
+    <%= link_to "Remove", "#", class: "btn btn-sm btn-outline-primary", data: { action: "click->form-nested-list#remove" } %>
+  </div>
+<% end %>

--- a/app/views/admin/integrations/_form_fields_nested_object.html.erb
+++ b/app/views/admin/integrations/_form_fields_nested_object.html.erb
@@ -1,0 +1,24 @@
+<% if spec['title'] %>
+  <h6>
+    <%=
+      label_with_tooltip(
+        config_field_title(name, spec),
+        spec['description']
+      )
+    %>
+  </h6>
+<% end %>
+<%= tag.div class: 'indented ml-2 mb-3 nested-object' do %>
+  <%=
+    render partial: 'form_fields',
+      locals: {
+        form: form,
+        namespace: name,
+        spec: spec,
+        current: current,
+        is_array: is_array
+      }
+  %>
+
+  <%= yield if block_given? %>
+<% end %>

--- a/app/views/resources/_form.html.erb
+++ b/app/views/resources/_form.html.erb
@@ -4,7 +4,12 @@
     scope: :resource,
     url: project_resources_path(resource.project, type: resource_type[:id]),
     method: :post,
-    local: true
+    local: true,
+    class: 'resource-form',
+    data: {
+      controller: 'resource-form',
+      'resource-form-integration-id': @resource.integration_id
+    }
   ) do |form|
 %>
   <%= form.alert_message "Please fix the issues below:" %>
@@ -21,7 +26,12 @@
         ),
         required: true
       },
-      { class: 'selectpicker' }
+      {
+        class: 'selectpicker',
+        data: {
+          action: 'resource-form#setCurrentIntegration'
+        }
+      }
   %>
 
   <%=
@@ -29,6 +39,73 @@
       help: Resource::SLUG_FORMAT_TEXT.capitalize,
       pattern: "^#{Resource::SLUG_FORMAT_REGEX}$"
   %>
+
+  <% integrations.each do |i| %>
+    <div data-target="resource-form.section" data-integration-id="<%= i.id -%>">
+      <%- case i.provider_id -%>
+      <%- when 'git_hub' -%>
+        <% enabled = current_user.identities.exists?(integration_id: i.id) %>
+        <%=
+          tag.fieldset(
+            class: 'form-group my-4',
+            disabled: !enabled
+          ) do
+        %>
+          <legend>Initialise from a template?</legend>
+
+          <% unless enabled %>
+            <div class="card bg-light mb-3">
+              <div class="card-body p-2">
+                You can only use templates once you've
+                <%= link_to 'connected up your GitHub identity', me_access_path(anchor: i.id) %>.
+                This is because we use the
+                <%= link_to 'GitHub Source Imports API', 'https://developer.github.com/v3/migrations/source_imports/' %>
+                which requires a User-to-Server auth token.
+              </div>
+            </div>
+          <% else %>
+            <%= form.fields_for :git_hub do |integration_form| %>
+              <% templates = i.config['templates'] %>
+              <% if templates.present? %>
+                <%=
+                  integration_form.select :template_url,
+                    templates.map { |t|
+                      [
+                        "#{t['name']} (#{t['repo_url']})",
+                        t['repo_url']
+                      ]
+                    },
+                    {
+                      label: label_with_tooltip(
+                        'Choose from existing options',
+                        'These are set up by a hub admin'
+                      ),
+                      include_blank: true
+                    },
+                    {
+                      class: 'selectpicker',
+                      disabled: !enabled
+                    }
+                %>
+
+                <p class="font-weight-bold">
+                  OR
+                </p>
+              <% end %>
+
+              <%=
+                integration_form.url_field :template_url,
+                  value: nil,
+                  disabled: !enabled,
+                  label: 'Specify a custom template repo URL',
+                  help: "Needs to be compatible with #{link_to('the GitHub Source Imports API', 'https://developer.github.com/v3/migrations/source_imports/', target: '_blank')}".html_safe
+              %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <%- end -%>
+    </div>
+  <% end %>
 
   <%= form.primary 'Request' %>
 <% end %>

--- a/app/views/resources/_list-item.html.erb
+++ b/app/views/resources/_list-item.html.erb
@@ -16,6 +16,7 @@
     </span>
     <%= resource_status_badge resource.status, css_class: 'ml-2' %>
   </h3>
+
   <% unless resource.pending? %>
     <div class="mb-2">
       <%- case resource -%>
@@ -36,6 +37,14 @@
               <%= resource.enforce_best_practices %>
             </span>
           </div>
+
+          <% if resource.template_url.present? %>
+            <div class="indented mt-3">
+              From template
+              <br />
+              <%= link_to resource.template_url, resource.template_url, target: '_blank' %>
+            </div>
+          <% end %>
         <% end %>
       <%- when Resources::DockerRepo -%>
         <span class="badge badge-secondary mr-1">
@@ -87,4 +96,8 @@
       <% end %>
     <% end %>
   <% end %>
+
+  <p class="small mb-0 mt-3">
+    Requested by: <%= resource.requested_by.email %>
+  </p>
 </div>

--- a/app/views/resources/new.html.erb
+++ b/app/views/resources/new.html.erb
@@ -1,5 +1,6 @@
 <h1>
-  Request a new resource
+  Request a new
+  <%= @resource_type[:name].singularize.downcase -%>
   for <%= @project.name -%> space
 </h1>
 

--- a/app/webpack/controllers/form_nested_list_controller.js
+++ b/app/webpack/controllers/form_nested_list_controller.js
@@ -1,0 +1,24 @@
+// Visit The Stimulus Handbook for more details
+// https://stimulusjs.org/handbook/introduction
+
+import { Controller } from 'stimulus';
+
+export default class extends Controller {
+  static targets = ['template', 'links'];
+
+  nestedObjectClass = 'nested-object';
+
+  add(event) {
+    event.preventDefault();
+
+    const content = this.templateTarget.innerHTML;
+    this.linksTarget.insertAdjacentHTML('beforebegin', content);
+  }
+
+  remove(event) {
+    event.preventDefault();
+
+    const nestedObject = event.target.closest(`.${this.nestedObjectClass}`);
+    nestedObject.remove();
+  }
+}

--- a/app/webpack/controllers/resource_form_controller.js
+++ b/app/webpack/controllers/resource_form_controller.js
@@ -1,0 +1,34 @@
+// Visit The Stimulus Handbook for more details
+// https://stimulusjs.org/handbook/introduction
+
+import { Controller } from 'stimulus';
+
+export default class extends Controller {
+  static targets = ['section'];
+
+  initialize() {
+    this.showCurrentSection();
+  }
+
+  setCurrentIntegration(event) {
+    this.integrationId = event.currentTarget.value;
+  }
+
+  showCurrentSection() {
+    this.sectionTargets.forEach(el => {
+      el.classList.toggle(
+        'd-none',
+        el.dataset.integrationId !== this.integrationId
+      );
+    });
+  }
+
+  get integrationId() {
+    return this.data.get('integrationId');
+  }
+
+  set integrationId(value) {
+    this.data.set('integrationId', value);
+    this.showCurrentSection();
+  }
+}

--- a/app/webpack/stylesheets/application.scss
+++ b/app/webpack/stylesheets/application.scss
@@ -6,6 +6,7 @@
 
 @import './theme/bootswatch';
 
+@import './forms';
 @import './sidebar';
 @import './projects';
 @import './activity';

--- a/app/webpack/stylesheets/forms.scss
+++ b/app/webpack/stylesheets/forms.scss
@@ -1,0 +1,17 @@
+fieldset {
+  @extend .p-3;
+  border: 1px solid $border-color;
+  position: relative;
+  border-radius: $border-radius;
+}
+
+legend {
+  @extend .py-2;
+  @extend .px-3;
+  font-size: 1em;
+  font-weight: bold;
+  margin-bottom: 0;
+  border: 1px solid $border-color;
+  border-radius: $border-radius;
+  width: auto;
+}

--- a/app/workers/resources/request_create_worker.rb
+++ b/app/workers/resources/request_create_worker.rb
@@ -3,17 +3,10 @@ module Resources
     HANDLERS = {
       'Resources::CodeRepo' => {
         'git_hub' => lambda do |resource, agent, config|
-          all_team_id = config['all_team_id']
-          enforce_best_practices = config['enforce_best_practices']
+          Resources::CreateGitHubCodeRepoService
+            .new(agent)
+            .call(resource, config)
 
-          result = agent.create_repository resource.name,
-            team_id: all_team_id,
-            best_practices: enforce_best_practices
-
-          resource.private = result.private
-          resource.full_name = result.full_name
-          resource.url = result.html_url
-          resource.enforce_best_practices = enforce_best_practices
           true
         end
       },

--- a/config/providers.yml
+++ b/config/providers.yml
@@ -37,6 +37,22 @@
         description: "If enabled, all repositories created will have their master branches protected for all users (including admins) with: require pull request reviews before merging and require branches to be up to date before merging."
         type: boolean
         overridable: true
+      templates:
+        title: Repository templates
+        description: "A list of Git repositories that can be used as templates for new repositories created using this integration. Must be publically accessible, or accessible by the org (if on GitHub)."
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              title: Name
+              type: string
+            repo_url:
+              title: Repository URL
+              type: string
+          required:
+            - name
+            - repo_url
     required:
       - org
       - all_team_id

--- a/db/migrate/20190708145925_add_requested_by_to_resources.rb
+++ b/db/migrate/20190708145925_add_requested_by_to_resources.rb
@@ -1,0 +1,5 @@
+class AddRequestedByToResources < ActiveRecord::Migration[5.2]
+  def change
+    add_column :resources, :requested_by_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_04_143604) do
+ActiveRecord::Schema.define(version: 2019_07_08_145925) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -116,6 +116,7 @@ ActiveRecord::Schema.define(version: 2019_07_04_143604) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "parent_id"
+    t.uuid "requested_by_id"
     t.index ["integration_id"], name: "index_resources_on_integration_id"
     t.index ["name", "integration_id"], name: "index_resources_on_name_and_integration_id", unique: true
     t.index ["project_id"], name: "index_resources_on_project_id"

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     sequence :name do |n|
       "resource-#{n}"
     end
+    association :requested_by, factory: :user
 
     factory :code_repo, class: 'Resources::CodeRepo' do
     end

--- a/spec/integration/resources/code_repos/git_hub_code_repos_integration_spec.rb
+++ b/spec/integration/resources/code_repos/git_hub_code_repos_integration_spec.rb
@@ -42,8 +42,12 @@ RSpec.describe 'Code Repos - GitHub' do
     let :agent_create_method_call_success do
       lambda do |agent, resource|
         expect(agent).to receive(:create_repository)
-          .with(resource.name, team_id: 1000, best_practices: true)
+          .with(resource.name, team_id: 1000, auto_init: true)
           .and_return(agent_create_response)
+
+        expect(agent).to receive(:apply_best_practices)
+          .with(agent_create_response.full_name)
+          .and_return(true)
       end
     end
 
@@ -59,7 +63,7 @@ RSpec.describe 'Code Repos - GitHub' do
     let :agent_create_method_call_error do
       lambda do |agent, resource|
         expect(agent).to receive(:create_repository)
-          .with(resource.name, team_id: 1000, best_practices: true)
+          .with(resource.name, team_id: 1000, auto_init: true)
           .and_raise('Something broked')
       end
     end

--- a/spec/lib/json_schema_helpers_spec.rb
+++ b/spec/lib/json_schema_helpers_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.describe JsonSchemaHelpers do
+  let :input_spec do
+    JsonSchema.parse!(
+      'properties' => {
+        'a_string' => { 'type' => 'string' },
+        'a_boolean' => { 'type' => 'boolean' },
+        'an_integer' => { 'type' => 'integer' },
+        'embedded_object' => {
+          'type' => 'object',
+          'properties' => {
+            'a_string' => { 'type' => 'string' },
+            'a_boolean' => { 'type' => 'boolean' },
+            'an_integer' => { 'type' => 'integer' }
+          }
+        },
+        'embedded_array_of_objects' => {
+          'type' => 'array',
+          'items' => {
+            'type' => 'object',
+            'properties' => {
+              'a_string' => { 'type' => 'string' },
+              'a_boolean' => { 'type' => 'boolean' },
+              'an_integer' => { 'type' => 'integer' }
+            }
+          }
+        }
+      }
+    )
+  end
+
+  let :input_data do
+    {
+      'a_string' => 'foo',
+      'a_boolean' => 'true',
+      'an_integer' => '42',
+      'embedded_object' => {
+        'a_string' => 'foo',
+        'a_boolean' => 'true',
+        'an_integer' => '42'
+      },
+      'embedded_array_of_objects' => [
+        {
+          'a_string' => 'foo',
+          'a_boolean' => 'true',
+          'an_integer' => '42'
+        },
+        {
+          'a_string' => 'foo',
+          'a_boolean' => 'true',
+          'an_integer' => '42'
+        }
+      ]
+    }
+  end
+
+  let :expected_output do
+    {
+      'a_string' => 'foo',
+      'a_boolean' => true,
+      'an_integer' => 42,
+      'embedded_object' => {
+        'a_string' => 'foo',
+        'a_boolean' => true,
+        'an_integer' => 42
+      },
+      'embedded_array_of_objects' => [
+        {
+          'a_string' => 'foo',
+          'a_boolean' => true,
+          'an_integer' => 42
+        },
+        {
+          'a_string' => 'foo',
+          'a_boolean' => true,
+          'an_integer' => 42
+        }
+      ]
+    }
+  end
+
+  it 'converts data types to the expected schema data types as expected' do
+    expect(
+      JsonSchemaHelpers.ensure_data_types(
+        input_data,
+        input_spec
+      )
+    ).to eq expected_output
+  end
+end

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -113,7 +113,10 @@ RSpec.describe 'Project resources', type: :request do
               {
                 type: 'Resources::CodeRepo',
                 integration_id: integration.id,
-                name: 'foo'
+                name: 'foo',
+                git_hub: {
+                  template_url: 'template_url'
+                }
               }
             end
 
@@ -132,8 +135,10 @@ RSpec.describe 'Project resources', type: :request do
                 expect(resource).to be_persisted
                 expect(resource).to be_a Resources::CodeRepo
                 expect(resource.integration).to eq integration
+                expect(resource.requested_by).to eq current_user
                 expect(resource.name).to eq params[:name]
                 expect(resource.created_at.to_i).to eq now.to_i
+                expect(resource.template_url).to eq 'template_url'
               end.to change { Resource.count }.by(1)
             end
 
@@ -259,6 +264,7 @@ RSpec.describe 'Project resources', type: :request do
           .with(@project)
           .and_return(project_bootstrap_service)
         expect(project_bootstrap_service).to receive(:bootstrap)
+          .with(requested_by: current_user)
       end
 
       it 'calls the ProjectResourcesBootstrapService as expected and redirects to the project page' do

--- a/spec/services/encryptor_service_spec.rb
+++ b/spec/services/encryptor_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe EncryptorService, type: :service do
+RSpec.describe EncryptorService, type: :service do
   let(:secret_key_base) { SecureRandom.base64(100) }
   let(:string) { 'my secret string' }
 

--- a/spec/services/project_resources_bootstrap_service_spec.rb
+++ b/spec/services/project_resources_bootstrap_service_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe ProjectResourcesBootstrapService, type: :service do
     instance_double('ResourceProvisioningService')
   end
 
+  let!(:user) { create :user }
+
   let!(:project) { create :project }
 
   subject do
@@ -27,13 +29,13 @@ RSpec.describe ProjectResourcesBootstrapService, type: :service do
 
       it 'does not provision any resources' do
         expect do
-          expect(subject.bootstrap).to be false
+          expect(subject.bootstrap(requested_by: user)).to be false
         end.not_to change(Resource, :count)
       end
 
       it 'does not log an audit' do
         expect do
-          subject.bootstrap
+          subject.bootstrap(requested_by: user)
         end.not_to change(project.audits, :count)
       end
     end
@@ -46,13 +48,13 @@ RSpec.describe ProjectResourcesBootstrapService, type: :service do
 
         it 'does not provision any resources' do
           expect do
-            expect(subject.bootstrap).to be false
+            expect(subject.bootstrap(requested_by: user)).to be false
           end.not_to change(Resource, :count)
         end
 
         it 'does not log an audit' do
           expect do
-            subject.bootstrap
+            subject.bootstrap(requested_by: user)
           end.not_to change(project.audits, :count)
         end
       end
@@ -73,7 +75,7 @@ RSpec.describe ProjectResourcesBootstrapService, type: :service do
           expect(Resources::KubeNamespace.count).to be 0
 
           expect do
-            expect(subject.bootstrap.length).to be 2
+            expect(subject.bootstrap(requested_by: user).length).to be 2
           end.to change(Resource, :count).by(2)
 
           expect(Resources::CodeRepo.count).to be 1
@@ -83,7 +85,7 @@ RSpec.describe ProjectResourcesBootstrapService, type: :service do
 
         it 'logs an audit for project_resources_bootstrap' do
           expect do
-            subject.bootstrap
+            subject.bootstrap(requested_by: user)
           end.to change(project.audits, :count).by(1)
 
           audit = project.audits.order(:created_at).last

--- a/spec/support/is_a_resource_examples.rb
+++ b/spec/support/is_a_resource_examples.rb
@@ -17,6 +17,11 @@ module IsAResourceExamples
         it { is_expected.to have_readonly_attribute(:integration_id) }
       end
 
+      describe '#requested_by' do
+        it { is_expected.to belong_to(:requested_by).class_name('User') }
+        it { is_expected.to have_readonly_attribute(:requested_by_id) }
+      end
+
       describe '#status' do
         it { is_expected.to define_enum_for(:status).backed_by_column_of_type(:string) }
         it { is_expected.to validate_presence_of(:status) }


### PR DESCRIPTION
Closes #165

- Uses the GitHub Source Import API…
- … which requires a User-to-Server auth token, and thus users can only select a template during creation if they've aleady connected their GitHub identity.
- Furthermore, resources now have a required `requested_by` field which points to the user that originally requested the resource – the auth token of this particular user will be used for the source import API call.
- Integration config now supports complex objects and arrays…
- … which is used to allow a list of repo templates to be configured for GitHub integrations…
- … which are then shown during the code repo creation if a GitHub integration is selected.
- The logic for applying best practices needed to be reworked to support waiting for the source import to complete – all this updated logic is now encapsulated in a new `Resources::CreateGitHubCodeRepoService` class.

---

**TODO:**

- [x] Remember to remove the `test_object` field in the `providers.yml`
- [x] Update the GitHub integration spec(s) to test out the new `template_url` flow too
- [x] Test flow locally (manually) when no templates have been configured at all
- [x] Support providing an arbitrary template repo URL in the resource create form
- [x] BEFORE deploy
    - [x] Delete all resources on the AWS demo site
- [x] AFTER deploy
    - [x] For demo instructions: need to add permission "Repository contents" to GitHub App

**Open issues to consider:**

- How to handle error case of no access token available for the `requested_by` user, during the `Resources::CreateGitHubCodeRepoService` flow?
- The GitHub Source Import will pause if it think credentials are needed to access the repo being used as the source (i.e. the template), in which case the source import poller/wait process will finish after a few tries, and best practices will fail to apply. At the moment we don't capture when this edge case happens.
