### PR TITLE
Fix the options select vs custom template_url

### DIFF
--- a/app/views/resources/_form.html.erb
+++ b/app/views/resources/_form.html.erb
@@ -80,6 +80,7 @@
                         'Choose from existing options',
                         'These are set up by a hub admin'
                       ),
+                      selected: params.dig('resource', 'git_hub', 'template_url'),
                       include_blank: true
                     },
                     {
@@ -94,8 +95,8 @@
               <% end %>
 
               <%=
-                integration_form.url_field :template_url,
-                  value: nil,
+                integration_form.url_field :template_url_custom,
+                  value: params.dig('resource', 'git_hub', 'template_url_custom'),
                   disabled: !enabled,
                   label: 'Specify a custom template repo URL',
                   help: "Needs to be compatible with #{link_to('the GitHub Source Imports API', 'https://developer.github.com/v3/migrations/source_imports/', target: '_blank')}".html_safe


### PR DESCRIPTION
This now splits the two options in to separate form inputs/values instead of relying on esoteric behaviour of a single overloaded form value.