### PR TITLE
UI: Disable delete action for Spaces that contain resources

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,23 +26,26 @@ module ApplicationHelper
     request.params.dup.merge("#{param}": nil)
   end
 
-  def icon(name, size: '1x', css_class: [], title: nil, data_attrs: nil)
+  def icon(name, size: '1x', css_class: [], style: '', title: nil, data_attrs: nil)
     tag.i '',
       class: ['fas', "fa-#{name}", "fa-#{size}"] + Array(css_class),
+      style: style,
       title: title,
       data: data_attrs
   end
 
-  def brand_icon(name, size: '1x', css_class: [], title: nil, data_attrs: nil)
+  def brand_icon(name, size: '1x', css_class: [], style: '', title: nil, data_attrs: nil)
     tag.i '',
       class: ['fab', "fa-#{name}", "fa-#{size}"] + Array(css_class),
+      style: style,
       title: title,
       data: data_attrs
   end
 
-  def icon_with_tooltip(text, icon_name: 'question-circle', css_class: [])
+  def icon_with_tooltip(text, icon_name: 'question-circle', css_class: [], style: '')
     icon icon_name,
       css_class: css_class,
+      style: style,
       title: text,
       data_attrs: {
         toggle: 'tooltip'

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -1,15 +1,30 @@
 module ProjectsHelper
   def delete_project_link(project, css_class: nil)
-    link_to 'Delete',
-      project_path(project),
-      method: :delete,
-      class: css_class,
-      data: {
-        confirm: 'Are you sure you want to delete this space permanently?',
-        title: "Delete space: #{project.slug}",
-        verify: project.slug,
-        verify_text: "Type '#{project.slug}' to confirm"
-      },
-      role: 'button'
+    if project.resources.count.positive?
+      tag.span class: css_class do
+        safe_join(
+          [
+            'Delete (unavailable)',
+            icon_with_tooltip(
+              'You can only delete this space once all resources are deleted from within it',
+              css_class: 'ml-2',
+              style: 'color: inherit'
+            )
+          ]
+        )
+      end
+    else
+      link_to 'Delete',
+        project_path(project),
+        method: :delete,
+        class: css_class,
+        data: {
+          confirm: 'Are you sure you want to delete this space permanently?',
+          title: "Delete space: #{project.slug}",
+          verify: project.slug,
+          verify_text: "Type '#{project.slug}' to confirm"
+        },
+        role: 'button'
+    end
   end
 end


### PR DESCRIPTION
Closes #189

Until we get to implementing a [proper deletion of spaces](https://github.com/appvia/appvia-hub/issues/98) this UI change disables the delete action when Spaces contain resources, which a useful info message.