### PR TITLE
Support for dependent/linked integrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ gem 'octokit', '~> 4.13'
 gem 'faraday', '~> 0.15.4'
 gem 'faraday_middleware', '~> 0.13.1'
 gem 'typhoeus', '~> 1.3', '>= 1.3.1'
-gem 'closure_tree', '~> 7.0'
 gem 'wait', '~> 0.5.3'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,9 +64,6 @@ GEM
       activemodel (>= 5.0)
     builder (3.2.3)
     byebug (11.0.1)
-    closure_tree (7.0.0)
-      activerecord (>= 4.2.10)
-      with_advisory_lock (>= 4.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
@@ -265,8 +262,6 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    with_advisory_lock (4.0.0)
-      activerecord (>= 4.2)
 
 PLATFORMS
   ruby
@@ -279,7 +274,6 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap_form (~> 4.2)
   byebug
-  closure_tree (~> 7.0)
   crypt_keeper (~> 2.0, >= 2.0.1)
   default_value_for (~> 3.1)
   dotenv-rails (~> 2.7.2)

--- a/app/helpers/integrations_helper.rb
+++ b/app/helpers/integrations_helper.rb
@@ -1,4 +1,13 @@
 module IntegrationsHelper
+  def admin_integrations_path_with_selected(integration)
+    resource_type = ResourceTypesService.for_provider integration.provider_id
+
+    admin_integrations_path(
+      expand: resource_type[:id],
+      anchor: integration.id
+    )
+  end
+
   def config_field_title(name, spec)
     if spec
       spec['title']

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -15,6 +15,10 @@ class Integration < ApplicationRecord
 
   attr_readonly :provider_id
 
+  validates :parent_ids,
+    presence: true,
+    if: :requires_a_parent?
+
   has_many :resources,
     dependent: :restrict_with_exception,
     inverse_of: :integration
@@ -23,6 +27,8 @@ class Integration < ApplicationRecord
     class_name: 'Identity',
     dependent: :restrict_with_exception,
     inverse_of: :integration
+
+  validate :check_parents
 
   def provider
     return if provider_id.blank?
@@ -42,5 +48,56 @@ class Integration < ApplicationRecord
 
   def descriptor
     name
+  end
+
+  def parents
+    self.class.where(id: parent_ids)
+  end
+
+  def children
+    self.class.where('parent_ids @> ARRAY[?]::uuid[]', Array(id))
+  end
+
+  private
+
+  def with_resource_type
+    resource_type = ResourceTypesService.for_integration self
+
+    yield resource_type if resource_type.present?
+  end
+
+  def requires_a_parent?
+    with_resource_type do |resource_type|
+      !resource_type[:top_level]
+    end
+  end
+
+  def check_parents
+    return if parent_ids.blank?
+
+    # Ensure that the parent_ids actually point to real integrations
+    all_exist = parent_ids.all? do |id|
+      self.class.exists? id
+    end
+    errors.add(:parent_ids, 'an unknown Integration ID has been found in the parent IDs') unless all_exist
+
+    # Ensure only the correct types of integrations can be linked together
+    with_resource_type do |resource_type|
+      all_allowed_provider_ids = parents.all? do |i|
+        resource_type[:depends_on].include?(i.provider_id)
+      end
+      errors.add(:parent_ids, 'an invalid parent has been detected') unless all_allowed_provider_ids
+    end
+
+    # Ensure that a particular parent integration only has one of a particular
+    # child integration type
+    has_existing_child = parents.any? do |i|
+      if i.children.size.zero?
+        false
+      else
+        i.children.any? { |c| c.provider_id == provider_id }
+      end
+    end
+    errors.add(:parent_ids, 'cannot link this to a parent as it already has a child integration of the same type') if has_existing_child
   end
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -6,7 +6,17 @@ class Resource < ApplicationRecord
 
   audited associated_with: :project
 
-  has_closure_tree order: 'integration_id', dependent: nil
+  belongs_to :parent,
+    class_name: 'Resource',
+    inverse_of: :children,
+    optional: true
+
+  has_many :children,
+    -> { order(:integration_id) },
+    foreign_key: 'parent_id',
+    class_name: 'Resource',
+    inverse_of: :parent,
+    dependent: nil
 
   belongs_to :project,
     -> { readonly },

--- a/app/services/dependent_integrations_service.rb
+++ b/app/services/dependent_integrations_service.rb
@@ -1,0 +1,20 @@
+module DependentIntegrationsService
+  class << self
+    def potential_parents_for(provider_id)
+      ResourceTypesService
+        .for_provider(provider_id)
+        .fetch(:depends_on, [])
+        .map { |parent_provider_id| ResourceTypesService.for_provider parent_provider_id }
+        .map { |resource_type| ResourceTypesService.integrations_for resource_type[:id] }
+        .flatten
+        .group_by { |i| i.provider['name'] }
+    end
+
+    def find_dependent_for(integration, for_resource_type_id)
+      integration.children.find do |c|
+        rt = ResourceTypesService.for_integration c
+        rt[:id] == for_resource_type_id
+      end
+    end
+  end
+end

--- a/app/services/resource_provisioning_service.rb
+++ b/app/services/resource_provisioning_service.rb
@@ -26,14 +26,17 @@ class ResourceProvisioningService
   end
 
   def request_dependent_create(parent_resource, resource_type_id)
+    dependent_integration = DependentIntegrationsService.find_dependent_for(
+      parent_resource.integration,
+      resource_type_id
+    )
+
+    return if dependent_integration.blank?
+
     resource_type = ResourceTypesService.get resource_type_id
-    integrations = ResourceTypesService.integrations_for(resource_type[:id])
-
-    return if integrations.empty?
-
     resource_class = resource_type[:class].constantize
     dependent_resource = resource_class.create!(
-      integration: integrations.first,
+      integration: dependent_integration,
       requested_by: parent_resource.requested_by,
       parent: parent_resource,
       project: parent_resource.project,

--- a/app/services/resource_types_service.rb
+++ b/app/services/resource_types_service.rb
@@ -12,41 +12,45 @@ module ResourceTypesService
     extend Memoist
     # rubocop:disable Metrics/MethodLength
     def all
+      # IMPORTANT: currently we expect a 1:1 mapping between a provider ID and a
+      # Resource Type - i.e. a provider can only ever be for one resource type.
       [
         {
           id: 'CodeRepo',
           class: 'Resources::CodeRepo',
           name: 'Code Repositories',
-          top_level: true,
-          providers: %w[git_hub].freeze
+          providers: %w[git_hub].freeze,
+          top_level: true
         },
         {
           id: 'DockerRepo',
           class: 'Resources::DockerRepo',
           name: 'Docker Repositories',
-          top_level: true,
-          providers: %w[ecr quay].freeze
+          providers: %w[ecr quay].freeze,
+          top_level: true
         },
         {
           id: 'KubeNamespace',
           class: 'Resources::KubeNamespace',
           name: 'Kubernetes Namespaces',
-          top_level: true,
-          providers: %w[kubernetes].freeze
+          providers: %w[kubernetes].freeze,
+          top_level: true
         },
         {
           id: 'MonitoringDashboard',
           class: 'Resources::MonitoringDashboard',
           name: 'Monitoring Dashboards',
+          providers: %w[grafana].freeze,
           top_level: false,
-          providers: %w[grafana].freeze
+          depends_on: %w[kubernetes].freeze
         },
         {
           id: 'LoggingDashboard',
           class: 'Resources::LoggingDashboard',
           name: 'Logging Dashboard',
+          providers: %w[loki].freeze,
           top_level: false,
-          providers: %w[loki].freeze
+          depends_on: %w[kubernetes].freeze
         }
       ].map(&:freeze).freeze
     end

--- a/app/views/admin/integrations/_card.html.erb
+++ b/app/views/admin/integrations/_card.html.erb
@@ -4,11 +4,40 @@
   <div class="card-body">
     <h5 class="card-title">
       Name: <%= integration.name %>
+      <%= link_to admin_integrations_path_with_selected(integration) do %>
+        <%= icon 'link', css_class: ['ml-1', 'text-muted'] %>
+      <% end %>
     </h5>
 
     <p class="text-muted">
       <%= pluralize integration.resources.count, 'resource' %>
     </p>
+
+    <% parents = integration.parents %>
+    <% children = integration.children %>
+    <% if parents.present? || children.present? %>
+      <hr />
+
+      <% if parents.present? %>
+        <h6 class="font-weight-bold">Depends on</h6>
+        <% parents.each do |p| %>
+          <div class="indented mb-1">
+            <%= link_to p.name, admin_integrations_path_with_selected(p) %>
+          </div>
+        <% end %>
+      <% end %>
+
+      <% if children.present? %>
+        <h6 class="font-weight-bold">Has dependents</h6>
+        <% children.each do |c| %>
+          <div class="indented mb-1">
+            <%= link_to c.name, admin_integrations_path_with_selected(c) %>
+          </div>
+        <% end %>
+      <% end %>
+
+      <hr />
+    <% end %>
 
     <%=
       render partial: 'config_fields',

--- a/app/views/admin/integrations/_form.html.erb
+++ b/app/views/admin/integrations/_form.html.erb
@@ -9,10 +9,25 @@
 %>
   <%= form.alert_message "Please fix the issues below:" %>
 
-  <h5>For: <%= integration.provider['name'] -%></h5>
+  <h5>Provider: <%= integration.provider['name'] -%></h5>
   <%= form.hidden_field :provider_id %>
 
   <%= form.text_field :name, layout: :default, input_group_class: 'input-group-lg' %>
+
+  <% if @potential_parents.present? %>
+    <%=
+      form.select :parent_ids,
+        @potential_parents.transform_values { |l| l.map { |i| [i.name, i.id] }},
+        {
+          label: 'Link with parent(s)',
+          layout: :default
+        },
+        {
+          class: 'selectpicker',
+          multiple: true
+        }
+    %>
+  <% end %>
 
   <div class="card mb-3">
     <div class="card-header">

--- a/app/workers/resources/request_create_worker.rb
+++ b/app/workers/resources/request_create_worker.rb
@@ -28,8 +28,10 @@ module Resources
         'kubernetes' => lambda do |resource, agent, _config|
           agent.create_namespace resource.name
 
-          ResourceProvisioningService.new.request_dependent_create resource, 'MonitoringDashboard'
-          ResourceProvisioningService.new.request_dependent_create resource, 'LoggingDashboard'
+          provisioning_service = ResourceProvisioningService.new
+
+          provisioning_service.request_dependent_create resource, 'MonitoringDashboard'
+          provisioning_service.request_dependent_create resource, 'LoggingDashboard'
 
           true
         end

--- a/db/migrate/20190717134327_drop_resource_hierarchies.rb
+++ b/db/migrate/20190717134327_drop_resource_hierarchies.rb
@@ -1,0 +1,7 @@
+class DropResourceHierarchies < ActiveRecord::Migration[5.2]
+  def change
+    # rubocop:disable Rails/ReversibleMigration
+    drop_table :resource_hierarchies
+    # rubocop:enable Rails/ReversibleMigration
+  end
+end

--- a/db/migrate/20190717151518_add_parent_id_to_integrations.rb
+++ b/db/migrate/20190717151518_add_parent_id_to_integrations.rb
@@ -1,0 +1,5 @@
+class AddParentIdToIntegrations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :integrations, :parent_ids, :uuid, array: true, null: false, default: [], index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_17_134327) do
+ActiveRecord::Schema.define(version: 2019_07_17_151518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 2019_07_17_134327) do
     t.text "config", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "parent_ids", default: [], null: false, array: true
     t.index ["name"], name: "index_integrations_on_name", unique: true
     t.index ["provider_id"], name: "index_integrations_on_provider_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_08_145925) do
+ActiveRecord::Schema.define(version: 2019_07_17_134327) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -95,14 +95,6 @@ ActiveRecord::Schema.define(version: 2019_07_08_145925) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["slug"], name: "index_projects_on_slug", unique: true
-  end
-
-  create_table "resource_hierarchies", id: false, force: :cascade do |t|
-    t.uuid "ancestor_id", null: false
-    t.uuid "descendant_id", null: false
-    t.integer "generations", null: false
-    t.index ["ancestor_id", "descendant_id", "generations"], name: "resource_anc_desc_idx", unique: true
-    t.index ["descendant_id"], name: "resource_desc_idx"
   end
 
   create_table "resources", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/integration/resources/kube_namespaces/kubernetes_kube_namespaces_integration_spec.rb
+++ b/spec/integration/resources/kube_namespaces/kubernetes_kube_namespaces_integration_spec.rb
@@ -31,12 +31,12 @@ RSpec.describe 'Kube Namespaces – Kubernetes' do
       }
     end
 
-    let :grafana_integration do
-      create_mocked_integration provider_id: 'grafana'
+    let! :grafana_integration do
+      create_mocked_integration provider_id: 'grafana', parent_ids: [integration.id]
     end
 
-    let :loki_integration do
-      create_mocked_integration provider_id: 'loki'
+    let! :loki_integration do
+      create_mocked_integration provider_id: 'loki', parent_ids: [integration.id]
     end
 
     let :dependents do

--- a/spec/integration/resources/logging_dashboards/loki_logging_dashboards_integration_spec.rb
+++ b/spec/integration/resources/logging_dashboards/loki_logging_dashboards_integration_spec.rb
@@ -11,9 +11,12 @@ RSpec.describe 'Logging Dashboards – Loki' do
       }
     end
 
+    let :parent_integration do
+      create_mocked_integration provider_id: 'kubernetes'
+    end
+
     let! :parent do
-      kubernetes_integration = create_mocked_integration provider_id: 'kubernetes'
-      create :kube_namespace, integration: kubernetes_integration
+      create :kube_namespace, integration: parent_integration
     end
 
     let! :resource do

--- a/spec/integration/resources/monitoring_dashboards/grafana_monitoring_dashboards_integration_spec.rb
+++ b/spec/integration/resources/monitoring_dashboards/grafana_monitoring_dashboards_integration_spec.rb
@@ -13,9 +13,12 @@ RSpec.describe 'Monitoring Dashboards – Grafana' do
       }
     end
 
+    let :parent_integration do
+      create_mocked_integration provider_id: 'kubernetes'
+    end
+
     let! :parent do
-      kubernetes_integration = create_mocked_integration provider_id: 'kubernetes'
-      create :kube_namespace, integration: kubernetes_integration
+      create :kube_namespace, integration: parent_integration
     end
 
     let! :resource do

--- a/spec/support/mocked_integration_helper.rb
+++ b/spec/support/mocked_integration_helper.rb
@@ -16,12 +16,13 @@ module MockedIntegrationHelper
         .and_return(true)
     end
 
-    def create_mocked_integration(provider_id: Integration.provider_ids.keys.first, config: { 'foo' => 'bar' }, schema: nil)
+    def create_mocked_integration(provider_id: Integration.provider_ids.keys.first, config: { 'foo' => 'bar' }, schema: nil, parent_ids: [])
       mock_provider_config_schema provider_id, schema: schema
 
       create :integration,
         provider_id: provider_id,
-        config: config
+        config: config,
+        parent_ids: parent_ids
     end
   end
 end

--- a/spec/support/resource_integration_specs_examples.rb
+++ b/spec/support/resource_integration_specs_examples.rb
@@ -3,9 +3,16 @@ module ResourceIntegrationSpecsExamples
     include_context 'time helpers'
 
     let! :integration do
+      parent_ids = if defined?(parent_integration)
+                     [parent_integration.id]
+                   else
+                     []
+                   end
+
       create :integration,
         provider_id: provider_id,
-        config: integration_config
+        config: integration_config,
+        parent_ids: parent_ids
     end
 
     let! :provisioning_service do
@@ -49,9 +56,9 @@ module ResourceIntegrationSpecsExamples
               .with(resource, d[:type])
               .and_call_original
 
-            expect(ResourceTypesService).to receive(:integrations_for)
-              .with(d[:type])
-              .and_return([d[:integration]])
+            expect(DependentIntegrationsService).to receive(:find_dependent_for)
+              .with(integration, d[:type])
+              .and_call_original
           end
         end
 


### PR DESCRIPTION
This fixes the issue where `grafana` and `loki` integrations were previously not tied to a specific `kubernetes` integration, and thus multiple `kubernetes` integrations would not get dependent resources as expected.

Now, certain integrations – as marked within the relevant Resource Type – _depend on_ parent integration(s). Child integrations can have multiple parents (which allows for reuse of a single child integration for multiple parents – e.g. a single Grafana integration for multiple Kubernetes Clusters).

When creating (or editing) integrations that require a parent, the form will provide the relevant parent options and allow multiple selection. However the following validations are in place at the model level (specifically for integrations that require a parent):
- At least one parent is set.
- Ensure only the correct types of integrations can be linked together.
- Ensure that a particular parent integration only has one of a particular child integration type (e.g. a Kubernetes Cluster should not be able to have multiple Grafana integrations [otherwise we don't know which one to use when provisioning dependent resources]).

Finally, the new children integrations are used when provisioning a resource that uses the parent integration, to determine which integration to use for dependent resources.

---

Also includes:

Remove the `closure_tree` gem and implement parent/children relationships ourselves

`closure_tree` is a bit too heavyweight for our needs at the moment.

---

**TODO**

- [x] Fix existing specs that don't pass due to these changes
- [x] Write more specs?
- [x] Test flow manually