### PR TITLE
Admin: Ability to delete integrations that don't have any resources

### DIFF
--- a/app/controllers/admin/integrations_controller.rb
+++ b/app/controllers/admin/integrations_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class IntegrationsController < Admin::BaseController
-    before_action :find_integration, only: %i[edit update]
+    before_action :find_integration, only: %i[edit update destroy]
 
     # GET /admin/integrations
     def index
@@ -67,6 +67,12 @@ module Admin
         @potential_parents = find_potential_parents @integration.provider_id
         render :edit
       end
+    end
+
+    # DELETE /admin/integrations/:id
+    def destroy
+      @integration.destroy
+      redirect_to admin_integrations_path, notice: 'Integration was successfully deleted.'
     end
 
     private

--- a/app/helpers/integrations_helper.rb
+++ b/app/helpers/integrations_helper.rb
@@ -8,6 +8,35 @@ module IntegrationsHelper
     )
   end
 
+  def delete_integration_link(integration, css_class: nil)
+    if integration.resources.count.positive?
+      tag.span class: css_class do
+        safe_join(
+          [
+            'Delete (unavailable)',
+            icon_with_tooltip(
+              'You can only delete this integration once all resources for it are deleted',
+              css_class: 'ml-2',
+              style: 'color: inherit'
+            )
+          ]
+        )
+      end
+    else
+      link_to 'Delete',
+        admin_integration_path(integration),
+        method: :delete,
+        class: css_class,
+        data: {
+          confirm: 'Are you sure you want to delete this integration permanently?',
+          title: "Delete integration: #{integration.name}",
+          verify: 'yes',
+          verify_text: "Type 'yes' to confirm"
+        },
+        role: 'button'
+    end
+  end
+
   def config_field_title(name, spec)
     if spec
       spec['title']

--- a/app/views/admin/integrations/_card.html.erb
+++ b/app/views/admin/integrations/_card.html.erb
@@ -3,6 +3,8 @@
 <div id="<%= integration.id -%>" class="card mb-3">
   <div class="card-body">
     <h5 class="card-title">
+      <%= delete_integration_link integration, css_class: 'float-right btn btn-sm btn-danger' %>
+
       Name: <%= integration.name %>
       <%= link_to admin_integrations_path_with_selected(integration) do %>
         <%= icon 'link', css_class: ['ml-1', 'text-muted'] %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ require 'sidekiq/web'
 # rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
   namespace :admin do
-    resources :integrations, except: %i[show destroy]
+    resources :integrations, except: %i[show]
     resource :settings, only: %i[show update]
   end
 

--- a/spec/routing/admin/integrations_routing_spec.rb
+++ b/spec/routing/admin/integrations_routing_spec.rb
@@ -25,5 +25,9 @@ RSpec.describe Admin::IntegrationsController, type: :routing do
     it 'routes to #update via PATCH' do
       expect(patch: '/admin/integrations/1').to route_to('admin/integrations#update', id: '1')
     end
+
+    it 'routes to #destroy' do
+      expect(delete: '/admin/integrations/1').to route_to('admin/integrations#destroy', id: '1')
+    end
   end
 end


### PR DESCRIPTION
Works the same way as the space (aka project) delete, except only available to hub admins.