### PR TITLE
UI: Fix resource form styling to be more consistent

### DIFF
--- a/app/views/resources/_form.html.erb
+++ b/app/views/resources/_form.html.erb
@@ -44,26 +44,25 @@
     <div data-target="resource-form.section" data-integration-id="<%= i.id -%>">
       <%- case i.provider_id -%>
       <%- when 'git_hub' -%>
-        <% enabled = current_user.identities.exists?(integration_id: i.id) %>
-        <%=
-          tag.fieldset(
-            class: 'form-group my-4',
-            disabled: !enabled
-          ) do
-        %>
-          <legend>Initialise from a template?</legend>
+        <div class="card my-4">
+          <div class="card-header">
+            Initialise from a template?
+          </div>
+          <div class="card-body">
+            <% enabled = current_user.identities.exists?(integration_id: i.id) %>
 
-          <% unless enabled %>
-            <div class="card bg-light mb-3">
-              <div class="card-body p-2">
-                You can only use templates once you've
-                <%= link_to 'connected up your GitHub identity', me_access_path(anchor: i.id) %>.
-                This is because we use the
-                <%= link_to 'GitHub Source Imports API', 'https://developer.github.com/v3/migrations/source_imports/' %>
-                which requires a User-to-Server auth token.
+            <% unless enabled %>
+              <div class="card bg-light mb-3">
+                <div class="card-body p-2">
+                  You can only use templates once you've
+                  <%= link_to 'connected up your GitHub identity', me_access_path(anchor: i.id) %>.
+                  This is because we use the
+                  <%= link_to 'GitHub Source Imports API', 'https://developer.github.com/v3/migrations/source_imports/' %>
+                  which requires a User-to-Server auth token.
+                </div>
               </div>
-            </div>
-          <% else %>
+            <% end %>
+
             <%= form.fields_for :git_hub do |integration_form| %>
               <% templates = i.config['templates'] %>
               <% if templates.present? %>
@@ -102,8 +101,8 @@
                   help: "Needs to be compatible with #{link_to('the GitHub Source Imports API', 'https://developer.github.com/v3/migrations/source_imports/', target: '_blank')}".html_safe
               %>
             <% end %>
-          <% end %>
-        <% end %>
+          </div>
+        </div>
       <%- end -%>
     </div>
   <% end %>


### PR DESCRIPTION
We don't use `<fieldset>` anywhere – instead we wrap sub forms in cards, so this change brings the resource form more in line with the other forms.