### PR TITLE
Restrict which audits we fetch for the activity stream

### DIFF
--- a/app/services/activity_service.rb
+++ b/app/services/activity_service.rb
@@ -1,6 +1,12 @@
 class ActivityService
   DEFAULT_PAGE_SIZE = 20
 
+  AUDITABLE_TYPES = %w[
+    User
+    Project
+    Resource
+  ].freeze
+
   def overall
     with_defaults(Audit.all)
   end
@@ -13,6 +19,7 @@ class ActivityService
 
   def with_defaults(scope)
     scope
+      .where(auditable_type: AUDITABLE_TYPES)
       .limit(DEFAULT_PAGE_SIZE)
       .order(created_at: :desc)
   end


### PR DESCRIPTION
Only pick the auditable types we know we show in the activity stream.

NOTE: this doesn't fully solve the issue of there being some fetched audits that still don't get shown in the UI – e.g. we don't show the audits for the `Resource` `create` in the activity streams (as we rely on the `request_create` instead). However, it's much harder to formulate a query to exclude just this particular case, so the net effect is we fetch up to 20 audits but may not show 20 activity stream items in the UI.