### PR TITLE
Fix CircleCI tags build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,12 @@ workflows:
   version: 2
   main:
     jobs:
-      - test
+      - test:
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
 
       - build_only:
           requires:


### PR DESCRIPTION
Steps need tags to be _whitelisted_ in order to work.