### PR TITLE
Scope spaces to teams

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,6 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.8', '>= 3.8.2'
   gem 'factory_bot_rails', '~> 5.0.1'
   gem 'rails-controller-testing', '~> 1.0', '>= 1.0.4'
-  gem 'shoulda-matchers', '~> 4.0.1'
   gem 'pry-rails', '~> 0.3.9'
   gem 'pry-byebug', '~> 3.7'
 end
@@ -54,6 +53,7 @@ end
 group :test do
   gem 'rspec_junit_formatter', '~> 0.4.1'
   gem 'timecop', '~> 0.9.1'
+  gem 'shoulda-matchers', '~> 4.1', '>= 4.1.2'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,7 +325,7 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
-    shoulda-matchers (4.0.1)
+    shoulda-matchers (4.1.2)
       activesupport (>= 4.2.0)
     sidekiq (5.2.5)
       connection_pool (~> 2.2, >= 2.2.2)
@@ -421,7 +421,7 @@ DEPENDENCIES
   rubocop (~> 0.73.0)
   rubocop-performance (~> 1.4.0)
   rubocop-rails (~> 2.2, >= 2.2.1)
-  shoulda-matchers (~> 4.0.1)
+  shoulda-matchers (~> 4.1, >= 4.1.2)
   sidekiq (~> 5.2.5)
   sidekiq-history (~> 0.0.11)
   spring

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,4 +1,6 @@
 class ProjectsController < ApplicationController
+  before_action :load_and_check_presence_of_teams, only: %i[new edit create update]
+
   before_action :find_project, only: %i[show edit update destroy]
 
   def index
@@ -18,7 +20,7 @@ class ProjectsController < ApplicationController
   end
 
   def new
-    @project = Project.new
+    @project = Project.new team_id: params[:team_id]
   end
 
   def edit; end
@@ -48,11 +50,20 @@ class ProjectsController < ApplicationController
 
   private
 
+  def load_and_check_presence_of_teams
+    @teams = Team.all
+
+    if @teams.empty? # rubocop:disable Style/GuardClause
+      flash[:warning] = 'No teams have been created yet, so spaces cannot be created.'
+      redirect_back fallback_location: root_path, allow_other_host: false
+    end
+  end
+
   def find_project
     @project = Project.friendly.find params[:id]
   end
 
   def project_params
-    params.require(:project).permit(:name, :slug, :description)
+    params.require(:project).permit(:name, :slug, :description, :team_id)
   end
 end

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -1,4 +1,8 @@
 module ProjectsHelper
+  def project_icon
+    icon 'cube'
+  end
+
   def delete_project_link(project, css_class: nil)
     if project.resources.count.positive?
       tag.span class: css_class do

--- a/app/helpers/sidebar_helper.rb
+++ b/app/helpers/sidebar_helper.rb
@@ -1,19 +1,19 @@
 module SidebarHelper
-  def nav_item(text, path, icon_name: nil)
+  def nav_item(text, path, icon: nil)
     link_classes = %w[nav-link text-nowrap]
     is_active = current_page? path
     link_classes << 'active' if is_active
 
     link_to path, class: link_classes do
-      concat(icon(icon_name)) if icon_name
+      concat(icon) if icon
       concat(tag.span(text))
       concat(tag.span('(current)', class: 'sr-only')) if is_active
     end
   end
 
-  def nav_list_item(text, path, icon_name: nil)
+  def nav_list_item(text, path, icon: nil)
     tag.li class: 'nav-item' do
-      nav_item text, path, icon_name: icon_name
+      nav_item text, path, icon: icon
     end
   end
 end

--- a/app/helpers/teams_helper.rb
+++ b/app/helpers/teams_helper.rb
@@ -1,4 +1,8 @@
 module TeamsHelper
+  def team_icon
+    icon 'user-friends'
+  end
+
   def delete_team_link(team, css_class: nil)
     link_to 'Delete',
       team_path(team),

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,7 +2,9 @@ class Project < ApplicationRecord
   include SluggedAttribute
   include FriendlyId
 
-  audited
+  audited associated_with: :team
+
+  belongs_to :team
 
   has_many :integration_overrides,
     dependent: :destroy,
@@ -33,6 +35,8 @@ class Project < ApplicationRecord
   friendly_id :slug
 
   validates :name, presence: true
+
+  attr_readonly :team_id
 
   def descriptor
     slug

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -13,6 +13,11 @@ class Team < ApplicationRecord
 
   validates :name, presence: true
 
+  has_many :projects,
+    -> { order(:name) },
+    dependent: :restrict_with_exception,
+    inverse_of: :team
+
   def descriptor
     slug
   end

--- a/app/views/activity/_stream.html.erb
+++ b/app/views/activity/_stream.html.erb
@@ -24,12 +24,12 @@
         <%- when 'Project' -%>
           <%- case a.action -%>
           <%- when 'create' -%>
-            <%= activity_entry icon('cube'), a.created_at do %>
+            <%= activity_entry project_icon, a.created_at do %>
               <%= a.user_email %> created a new space:
               <%= link_to a.auditable_descriptor, project_path(a.auditable_id), class: 'text-monospace' %>
             <% end %>
           <%- when 'destroy' -%>
-            <%= activity_entry icon('cube'), a.created_at do %>
+            <%= activity_entry project_icon, a.created_at do %>
               <%= a.user_email %> deleted space:
               <span class="text-monospace"><%= a.auditable_descriptor %></span>
             <% end %>

--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -7,12 +7,24 @@
     <hr />
 
     <div class="sidebar-item">
+      <%= link_to 'New', new_team_path, class: 'btn btn-sm btn-primary float-right mr-3' %>
+      <%= nav_item 'Teams', teams_path %>
+    </div>
+    <ul class="nav flex-column mb-3">
+      <% Team.order(:name).each do |team| %>
+        <%= nav_list_item team.name, team_path(team), icon: team_icon %>
+      <% end %>
+    </ul>
+
+    <hr />
+
+    <div class="sidebar-item">
       <%= link_to 'New', new_project_path, class: 'btn btn-sm btn-primary float-right mr-3' %>
       <%= nav_item 'Spaces', projects_path %>
     </div>
     <ul class="nav flex-column mb-3">
       <% Project.order(:name).each do |project| %>
-        <%= nav_list_item project.name, project_path(project), icon_name: 'cube' %>
+        <%= nav_list_item project.name, project_path(project), icon: project_icon %>
       <% end %>
     </ul>
 

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -1,6 +1,25 @@
 <%= bootstrap_form_with(model: project, local: true) do |form| %>
   <%= form.alert_message "Please fix the issues below:" %>
 
+  <% if project.new_record? %>
+    <%=
+      form.select :team_id,
+        teams.map { |i| [i.name, i.id] },
+        {
+          label: 'Team',
+          required: true
+        },
+        { class: 'selectpicker' }
+    %>
+  <% else %>
+    <%= form.hidden_field :team_id %>
+    <%=
+      form.static_control :team_name,
+        value: project.team.name,
+        label: 'Team'
+    %>
+  <% end %>
+
   <%= form.text_field :name %>
 
   <% if project.new_record? %>

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -1,3 +1,3 @@
 <h1>Edit Space</h1>
 
-<%= render 'form', project: @project %>
+<%= render 'form', project: @project, teams: @teams %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -10,7 +10,7 @@
   <div class="card shadow-sm mb-3">
     <div class="card-body">
       <h5 class="card-title">
-        <%= icon 'cube' %>
+        <%= project_icon %>
         <%= link_to project.name, project_path(project) %>
 
         <small class="badge badge-info ml-2 text-monospace">

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -1,3 +1,3 @@
 <h1>Create a new Space</h1>
 
-<%= render 'form', project: @project %>
+<%= render 'form', project: @project, teams: @teams %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,3 +1,14 @@
+<nav aria-label="breadcrumb" class="mb-3">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item">
+        <%= link_to team_path(@project.team) do %>
+          <%= icon 'angle-left' %>
+          <%= @project.team.name %>
+        <% end %>
+      </li>
+    </ol>
+  </nav>
+
 <div class="btn-group float-right" role="group" aria-label="Space actions">
   <button id="projectActionsGroupDropdown" type="button" class="btn btn-outline-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Actions
@@ -11,7 +22,7 @@
 </div>
 
 <h1>
-  <%= icon 'cube' %>
+  <%= project_icon %>
   <%= @project.name %>
 </h1>
 

--- a/app/views/teams/_projects.html.erb
+++ b/app/views/teams/_projects.html.erb
@@ -1,0 +1,18 @@
+<div class="team-projects">
+  <div class="list-group list-group-flush border-top">
+    <% team.projects.each do |project| %>
+      <div class="list-group-item">
+        <h3 class="h6 mb-0">
+          <%= link_to project_path(project) do %>
+            <%= project_icon %>
+            <%= project.name %>
+
+            <small class="badge badge-info ml-2 text-monospace">
+              <%= project.slug %>
+            </small>
+          <% end %>
+        </h3>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -10,7 +10,7 @@
   <div class="card shadow-sm mb-3">
     <div class="card-body">
       <h5 class="card-title">
-        <%= icon 'user-friends' %>
+        <%= team_icon %>
         <%= link_to team.name, team_path(team) %>
 
         <small class="badge badge-info ml-2 text-monospace">

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -9,7 +9,7 @@
 </div>
 
 <h1>
-  <%= icon 'user-friends' %>
+  <%= team_icon %>
   <%= @team.name %>
 </h1>
 
@@ -27,3 +27,47 @@
     <%= simple_format @team.description %>
   </div>
 <% end %>
+
+<ul class="nav nav-tabs" role="tablist">
+  <li class="nav-item">
+    <a class="nav-link active" id="projects-tab" data-toggle="tab" href="#spaces" role="tab" aria-controls="projects" aria-selected="true">Spaces</a>
+  </li>
+</ul>
+
+<div class="tab-content border border-top-0">
+  <div class="tab-pane active" id="projects" role="tabpanel" aria-labelledby="projects-tab">
+    <% if @team.projects.count.zero? %>
+      <div class="p-3 border-bottom">
+        <div class="card bg-light p-3 text-center">
+          <p class="lead">
+            This team has no spaces at the moment.
+          </p>
+
+          <p>
+            Spaces allow you to provision and group resources for your team.
+          </p>
+
+          <div>
+            <%=
+              link_to 'Create a new space...',
+                new_project_path(team_id: @team.id),
+                class: 'btn btn-primary',
+                role: 'button'
+            %>
+          </div>
+        </div>
+      </div>
+    <% else %>
+      <div class="text-right">
+        <%=
+          link_to 'New space',
+            new_project_path(team_id: @team.id),
+            class: 'btn btn-sm btn-primary my-2 mr-3',
+            role: 'button'
+        %>
+      </div>
+    <% end %>
+
+    <%= render partial: 'projects', locals: { team: @team } %>
+  </div>
+</div>

--- a/db/migrate/20190805135446_add_team_id_to_project.rb
+++ b/db/migrate/20190805135446_add_team_id_to_project.rb
@@ -1,0 +1,6 @@
+class AddTeamIdToProject < ActiveRecord::Migration[5.2]
+  def change
+    add_column :projects, :team_id, :uuid
+    add_index :projects, :team_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_05_083206) do
+ActiveRecord::Schema.define(version: 2019_08_05_135446) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -112,7 +112,9 @@ ActiveRecord::Schema.define(version: 2019_08_05_083206) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "team_id"
     t.index ["slug"], name: "index_projects_on_slug", unique: true
+    t.index ["team_id"], name: "index_projects_on_team_id"
   end
 
   create_table "resources", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :project do
+    team
     sequence :name do |n|
       "Project #{n}"
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -14,4 +14,9 @@ RSpec.describe Project, type: :model do
       uniqueness: true,
       readonly: true
   end
+
+  describe '#team' do
+    it { is_expected.to belong_to(:team) }
+    it { is_expected.to have_readonly_attribute(:team_id) }
+  end
 end

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Project resources', type: :request do
 
   shared_examples 'fails when no integrations are available for the resource type' do
     context 'when no integrations are available for the resource type' do
-      it 'redirects to the home page with an error flash message' do
+      it 'redirects to the home page with a warning flash message' do
         make_request
         expect(response).to redirect_to(root_path)
         expect(flash[:warning]).not_to be_empty
@@ -147,6 +147,7 @@ RSpec.describe 'Project resources', type: :request do
               resource = assigns(:resource)
               audit = resource.audits.order(:created_at).last
               expect(audit.action).to eq 'create'
+              expect(audit.associated).to eq @project
               expect(audit.user_email).to eq auth_email
               expect(audit.created_at.to_i).to eq now.to_i
             end


### PR DESCRIPTION
With this change, all spaces MUST be assigned to a team.

NOTE: for now, the sidebar contains the full list of both teams and spaces. This will change as we add users to teams and introduce permissions and access restrictions (e.g. this may change to show only the current user's teams and spaces).