### PR TITLE
Redo the teams and spaces links in the sidebar

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -22,6 +22,9 @@ class TeamsController < ApplicationController
     @team = Team.new team_params
 
     if @team.save
+      # Current user becomes an admin of the team
+      @team.memberships.create! user_id: current_user.id, role: 'admin'
+
       redirect_to @team, notice: 'Team was successfully created.'
     else
       render :new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,9 @@ class User < ApplicationRecord
     class_name: 'TeamMembership',
     dependent: :destroy
 
-  has_many :teams, through: :memberships
+  has_many :teams,
+    -> { order(:name) },
+    through: :memberships
 
   pg_search_scope :search,
     against: {

--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -6,27 +6,28 @@
 
     <hr />
 
-    <div class="sidebar-item">
-      <%= link_to 'New', new_team_path, class: 'btn btn-sm btn-primary float-right mr-3' %>
-      <%= nav_item 'Teams', teams_path %>
-    </div>
-    <ul class="nav flex-column mb-3">
-      <% Team.order(:name).each do |team| %>
+    <ul class="nav flex-column">
+      <% current_user.teams.each do |team| %>
         <%= nav_list_item team.name, team_path(team), icon: team_icon %>
+        <ul class="nav flex-column indented">
+          <% team.projects.each do |project| %>
+            <%= nav_list_item project.name, project_path(project), icon: project_icon %>
+          <% end %>
+        </ul>
       <% end %>
     </ul>
 
     <hr />
 
     <div class="sidebar-item">
-      <%= link_to 'New', new_project_path, class: 'btn btn-sm btn-primary float-right mr-3' %>
-      <%= nav_item 'Spaces', projects_path %>
+      <%= link_to 'New', new_team_path, class: 'btn btn-sm btn-primary float-right mr-3' %>
+      <%= nav_item 'All Teams', teams_path %>
     </div>
-    <ul class="nav flex-column mb-3">
-      <% Project.order(:name).each do |project| %>
-        <%= nav_list_item project.name, project_path(project), icon: project_icon %>
-      <% end %>
-    </ul>
+
+    <div class="sidebar-item">
+      <%= link_to 'New', new_project_path, class: 'btn btn-sm btn-primary float-right mr-3' %>
+      <%= nav_item 'All Spaces', projects_path %>
+    </div>
 
     <hr />
 


### PR DESCRIPTION
Now separated into the following sections:
- a tree of the current user's teams and spaces within those teams
- a link to "All Teams" with a "New" button
- a link to "All Spaces" with a "New" button

---

As part of this, also needed:

Make the creator of a team an admin of the team (the first commit in this PR)
