### PR TITLE
Lock down access to teams, spaces and resources based on team memberships and roles

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,8 @@ Layout/MultilineMethodCallIndentation:
 
 Metrics/AbcSize:
   Max: 40
+  Exclude:
+    - "spec/**/*"
 
 Metrics/BlockLength:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'hub-clusters-creator', github: 'appvia/hub-clusters-creator', tag: 'v0.0.7'
 gem 'pg_search', '~> 2.3'
 gem 'composite_primary_keys', '~> 11.2'
 gem 'active_model_serializers', '~> 0.10.10'
+gem 'cancancan', '~> 3.0', '>= 3.0.1'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
       activemodel (>= 5.0)
     builder (3.2.3)
     byebug (11.0.1)
+    cancancan (3.0.1)
     case_transform (0.2)
       activesupport
     coderay (1.1.2)
@@ -410,6 +411,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap_form (~> 4.2)
   byebug
+  cancancan (~> 3.0, >= 3.0.1)
   composite_primary_keys (~> 11.2)
   crypt_keeper (~> 2.0, >= 2.0.1)
   default_value_for (~> 3.1)

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,5 +1,4 @@
 module Admin
   class BaseController < ApplicationController
-    before_action :require_admin
   end
 end

--- a/app/controllers/admin/create_controller.rb
+++ b/app/controllers/admin/create_controller.rb
@@ -1,5 +1,7 @@
 module Admin
   class CreateController < BaseController
+    authorize_resource class: false
+
     def show
       @options = CLUSTER_CREATORS_REGISTRY.all
       @tasks = Admin::Tasks::CreateKubeCluster.all.order(updated_at: :desc)

--- a/app/controllers/admin/integrations_controller.rb
+++ b/app/controllers/admin/integrations_controller.rb
@@ -2,6 +2,8 @@ module Admin
   class IntegrationsController < BaseController
     before_action :find_integration, only: %i[edit update destroy]
 
+    authorize_resource
+
     # GET /admin/integrations
     def index
       integrations_by_provider = Integration.all.group_by(&:provider_id)

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,5 +1,7 @@
 module Admin
   class SettingsController < BaseController
+    authorize_resource :settings, parent: false, class: false
+
     # GET /admin/settings
     def show
       @settings = SettingsService.all

--- a/app/controllers/admin/tasks_controller.rb
+++ b/app/controllers/admin/tasks_controller.rb
@@ -1,5 +1,9 @@
 module Admin
   class TasksController < ApplicationController
+    before_action :find_admin_task, only: [:destroy]
+
+    authorize_resource class: 'Admin::Task', instance_name: 'admin_task'
+
     # GET /admin/tasks/new
     def new
       type = params.require(:type)
@@ -35,8 +39,6 @@ module Admin
 
     # DELETE /admin/tasks/:id
     def destroy
-      @admin_task = Admin::Task.find params[:id]
-
       if @admin_task.deleteable?
         @admin_task.destroy
         redirect_to admin_create_path, notice: 'Task successfully deleted.'
@@ -46,6 +48,10 @@ module Admin
     end
 
     private
+
+    def find_admin_task
+      @admin_task = Admin::Task.find params[:id]
+    end
 
     def admin_task_params
       params.require(:admin_task).permit(:type)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include ErrorHandlers
   include Authentication
+  include Authorization
 
   before_action :require_authentication
   before_action :record_last_seen!
@@ -11,10 +12,6 @@ class ApplicationController < ActionController::Base
   before_action :set_autorefresh
 
   protected
-
-  def require_admin
-    redirect_to root_path, alert: 'You need to be an admin to do that' unless current_user.admin?
-  end
 
   def set_autorefresh
     @autorefresh = params[:autorefresh] == 'true'

--- a/app/controllers/concerns/authorization.rb
+++ b/app/controllers/concerns/authorization.rb
@@ -1,0 +1,26 @@
+module Authorization
+  extend ActiveSupport::Concern
+
+  included do
+    check_authorization
+
+    rescue_from CanCan::AccessDenied do |exception|
+      logger.warn [
+        "AUTHORIZATION FAIL: user #{current_user.id} (#{current_user.email})",
+        'tried to a perform an action they are not authorized for:',
+        "action = #{exception.action}, subject = #{exception.subject},",
+        "message = #{exception.message}"
+      ].join(' ')
+
+      access_denied exception.message
+    end
+
+    def access_denied(message)
+      respond_to do |format|
+        format.js   { head :forbidden, content_type: 'text/html' }
+        format.json { head :forbidden, content_type: 'text/html' }
+        format.html { redirect_to root_path, alert: "Access denied: #{message}" }
+      end
+    end
+  end
+end

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,6 +1,8 @@
 class HealthcheckController < ApplicationController
   skip_before_action :require_authentication, only: :show
 
+  skip_authorization_check
+
   def show
     head :no_content
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,6 @@
 class HomeController < ApplicationController
+  skip_authorization_check
+
   def show
     @activity = ActivityService.new.overall
   end

--- a/app/controllers/me/access_controller.rb
+++ b/app/controllers/me/access_controller.rb
@@ -1,5 +1,9 @@
 module Me
   class AccessController < ApplicationController
+    # This controller should only ever act on the currently authenticated user,
+    # so we do not need to peform any authorization checks.
+    skip_authorization_check
+
     def show
       identities_by_integration = current_user
         .identities

--- a/app/controllers/me/identities_controller.rb
+++ b/app/controllers/me/identities_controller.rb
@@ -1,5 +1,9 @@
 module Me
   class IdentitiesController < ApplicationController
+    # This controller should only ever act on the currently authenticated user,
+    # so we do not need to peform any authorization checks.
+    skip_authorization_check
+
     before_action :find_integration
 
     def destroy

--- a/app/controllers/me/identity_flows_controller.rb
+++ b/app/controllers/me/identity_flows_controller.rb
@@ -5,6 +5,10 @@ module Me
       'git_hub_callback' => 'git_hub'
     }.freeze
 
+    # This controller should only ever act on the currently authenticated user,
+    # so we do not need to peform any authorization checks.
+    skip_authorization_check
+
     skip_before_action :require_authentication, only: :git_hub_callback
 
     before_action :find_integration

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -1,6 +1,8 @@
 class ResourcesController < ApplicationController
   before_action :find_project
 
+  authorize_resource :project
+
   before_action :find_resource_type, only: %i[new create]
   before_action :find_integrations_for_resource_type, only: %i[new create]
 

--- a/app/controllers/team_memberships_controller.rb
+++ b/app/controllers/team_memberships_controller.rb
@@ -1,7 +1,10 @@
 class TeamMembershipsController < ApplicationController
   before_action :find_team
 
+  # PUT /teams/:team_id/memberships/:id
   def update
+    authorize! :edit, @team
+
     @team_membership = team_membership_scope.first_or_initialize
 
     @team_membership.role = params[:role] if params.key?(:role)
@@ -17,7 +20,10 @@ class TeamMembershipsController < ApplicationController
     end
   end
 
+  # DELETE /teams/:team_id/memberships/:id
   def destroy
+    authorize! :edit, @team
+
     @team_membership = team_membership_scope.first
 
     @team_membership&.destroy

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,10 @@
 class TeamsController < ApplicationController
   before_action :find_team, only: %i[show edit update destroy]
 
+  skip_authorization_check only: %i[index new create]
+
+  authorize_resource except: %i[index new create]
+
   # GET /teams
   def index
     @teams = Team.order(:name)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :require_admin, only: [:update_role]
+  authorize_resource
 
   # GET /users
   def index

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -4,6 +4,8 @@ module ProjectsHelper
   end
 
   def delete_project_link(project, css_class: nil)
+    return unless can?(:destroy, project)
+
     if project.resources.count.positive?
       tag.span class: css_class do
         safe_join(

--- a/app/helpers/teams_helper.rb
+++ b/app/helpers/teams_helper.rb
@@ -4,6 +4,8 @@ module TeamsHelper
   end
 
   def delete_team_link(team, css_class: nil)
+    return unless can?(:destroy, team)
+
     link_to 'Delete',
       team_path(team),
       method: :delete,
@@ -42,8 +44,12 @@ module TeamsHelper
       class: css_class,
       data: {
         params: { role: role }.to_param,
+        'disable-with': 'Processing...',
         turbolinks: false,
-        'disable-with': 'Processing...'
+        confirm: 'Are you sure you want to update the role for this team member?',
+        title: "Update role for team member: #{user.email}",
+        verify: 'yes',
+        verify_text: "Type 'yes' to confirm"
       },
       role: 'button'
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # IMPORTANT: to understand the caveats when using blocks to specify
+    # abilities see: https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities-with-Blocks
+
+    # https://github.com/CanCanCommunity/cancancan/wiki/Ability-Precedence explains the precedence rules
+
+    # Hub admin role
+    can :manage, :all if user.admin?
+
+    can :read, User
+
+    # Teams and projects
+
+    can %i[new create], Team
+
+    can :show, Team do |team|
+      can_participate_in_team? team, user
+    end
+
+    can %i[edit update destroy], Team do |team|
+      can_administer_team? team, user
+    end
+
+    # In this particular case, we have to allow certain actions for projects
+    # that can't operate on a project instance (i.e. we don't have a project
+    # instance to be able to check if it's allowed by the user). Thus, we expect
+    # separate checks to happen at the team level instead, to authorize the user.
+    can %i[new create], Project
+
+    can %i[show edit update destroy], Project do |project|
+      can_participate_in_team? project.team, user
+    end
+  end
+
+  private
+
+  def can_administer_team?(team, user)
+    TeamMembershipsService.user_an_admin_of_team?(
+      team.id,
+      user.id
+    )
+  end
+
+  def can_participate_in_team?(team, user)
+    TeamMembershipsService.user_a_member_of_team?(
+      team.id,
+      user.id
+    )
+  end
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -3,6 +3,7 @@ class Team < ApplicationRecord
   include FriendlyId
 
   audited
+  has_associated_audits
 
   slugged_attribute :slug,
     presence: true,

--- a/app/services/team_memberships_service.rb
+++ b/app/services/team_memberships_service.rb
@@ -1,0 +1,21 @@
+module TeamMembershipsService
+  class << self
+    def user_a_member_of_team?(team_id, user_id)
+      scope.exists? team_id: team_id, user_id: user_id
+    end
+
+    def user_an_admin_of_team?(team_id, user_id)
+      admin_scope.exists? team_id: team_id, user_id: user_id
+    end
+
+    private
+
+    def scope
+      TeamMembership
+    end
+
+    def admin_scope
+      TeamMembership.admin
+    end
+  end
+end

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -7,16 +7,24 @@
 <% end %>
 
 <% @projects.each do |project| %>
-  <div class="card shadow-sm mb-3">
+  <% can_access = can? :show, project %>
+  <% can_delete = can? :destroy, project %>
+
+  <div class="card shadow-sm mb-3 <%= can_access ? nil : 'bg-light' -%>">
     <div class="card-body">
       <h5 class="card-title">
         <%= project_icon %>
-        <%= link_to project.name, project_path(project) %>
 
-        <small class="badge badge-info ml-2 text-monospace">
-          <%= project.slug %>
-        </small>
+        <% if can_access %>
+          <%= link_to project.name, project_path(project) %>
+        <% else %>
+          <%= project.name %>
+        <% end %>
       </h5>
+
+      <small class="badge badge-info text-monospace">
+        <%= project.slug %>
+      </small>
 
       <% if project.description.present? %>
         <div class="card-text mt-3">
@@ -24,8 +32,10 @@
         </div>
       <% end %>
     </div>
-    <div class="card-footer text-muted">
-      <%= delete_project_link project, css_class: 'float-right btn btn-danger' %>
-    </div>
+    <% if can_delete %>
+      <div class="card-footer text-muted">
+        <%= delete_project_link project, css_class: 'float-right btn btn-danger' %>
+      </div>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -10,17 +10,19 @@
     </ol>
   </nav>
 
-<div class="btn-group float-right" role="group" aria-label="Space actions">
-  <button id="projectActionsGroupDropdown" type="button" class="btn btn-outline-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    Actions
-  </button>
-  <div class="dropdown-menu dropdown-menu-right" aria-labelledby="projectActionsGroupDropdown">
-    <%= link_to 'Edit', edit_project_path(@project), class: 'dropdown-item' %>
-    <%= delete_project_link @project, css_class: 'dropdown-item' %>
-    <div class="dropdown-divider"></div>
-    <%= link_to 'Override integrations', project_integration_overrides_path(@project), class: 'dropdown-item' %>
+<% if can? :edit, @project %>
+  <div class="btn-group float-right" role="group" aria-label="Space actions">
+    <button id="projectActionsGroupDropdown" type="button" class="btn btn-outline-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      Actions
+    </button>
+    <div class="dropdown-menu dropdown-menu-right" aria-labelledby="projectActionsGroupDropdown">
+      <%= link_to 'Edit', edit_project_path(@project), class: 'dropdown-item' %>
+      <%= delete_project_link @project, css_class: 'dropdown-item' %>
+      <div class="dropdown-divider"></div>
+      <%= link_to 'Override integrations', project_integration_overrides_path(@project), class: 'dropdown-item' %>
+    </div>
   </div>
-</div>
+<% end %>
 
 <h1>
   <%= project_icon %>

--- a/app/views/teams/_people.html.erb
+++ b/app/views/teams/_people.html.erb
@@ -1,22 +1,24 @@
 <div class="team-people">
-  <div class="list-group list-group-flush border-top">
+  <div class="list-group list-group-flush">
     <% team.memberships.each do |membership| %>
       <% user = membership.user %>
       <div class="list-group-item">
-        <div class="btn-group float-right" role="group" aria-label="Team membership actions">
-          <button id="user<%= user.id -%>ActionsGroupDropdown" type="button" class="btn btn-sm btn-outline-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Actions
-          </button>
-          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="user<%= user.id -%>ActionsGroupDropdown">
-            <% if membership.admin? %>
-              <%= update_team_membership_role_link 'Revoke team admin', team, user, nil, css_class: 'dropdown-item' %>
-            <% else %>
-              <%= update_team_membership_role_link 'Make team admin', team, user, :admin, css_class: 'dropdown-item' %>
-            <% end %>
+        <% if can? :edit, @team %>
+          <div class="btn-group float-right" role="group" aria-label="Team membership actions">
+            <button id="user<%= user.id -%>ActionsGroupDropdown" type="button" class="btn btn-sm btn-outline-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              Actions
+            </button>
+            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="user<%= user.id -%>ActionsGroupDropdown">
+              <% if membership.admin? %>
+                <%= update_team_membership_role_link 'Revoke team admin', team, user, nil, css_class: 'dropdown-item' %>
+              <% else %>
+                <%= update_team_membership_role_link 'Make team admin', team, user, :admin, css_class: 'dropdown-item' %>
+              <% end %>
 
-            <%= delete_team_membership_link team, user, css_class: 'dropdown-item' %>
+              <%= delete_team_membership_link team, user, css_class: 'dropdown-item' %>
+            </div>
           </div>
-        </div>
+        <% end %>
 
         <h3 class="h6 mb-0">
           <%= user.email %>

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -7,16 +7,24 @@
 <% end %>
 
 <% @teams.each do |team| %>
-  <div class="card shadow-sm mb-3">
+  <% can_access = can? :show, team %>
+  <% can_delete = can? :destroy, team %>
+
+  <div class="card shadow-sm mb-3 <%= can_access ? nil : 'bg-light' -%>">
     <div class="card-body">
       <h5 class="card-title">
         <%= team_icon %>
-        <%= link_to team.name, team_path(team) %>
 
-        <small class="badge badge-info ml-2 text-monospace">
-          <%= team.slug %>
-        </small>
+        <% if can_access  %>
+          <%= link_to team.name, team_path(team) %>
+        <% else %>
+          <%= team.name %>
+        <% end %>
       </h5>
+
+      <small class="badge badge-info text-monospace">
+        <%= team.slug %>
+      </small>
 
       <% if team.description.present? %>
         <div class="card-text mt-3">
@@ -24,8 +32,10 @@
         </div>
       <% end %>
     </div>
-    <div class="card-footer text-muted">
-      <%= delete_team_link team, css_class: 'float-right btn btn-danger' %>
-    </div>
+    <% if can_delete %>
+      <div class="card-footer text-muted">
+        <%= delete_team_link team, css_class: 'float-right btn btn-danger' %>
+      </div>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -1,12 +1,14 @@
-<div class="btn-group float-right" role="group" aria-label="Team actions">
-  <button id="teamActionsGroupDropdown" type="button" class="btn btn-outline-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    Actions
-  </button>
-  <div class="dropdown-menu dropdown-menu-right" aria-labelledby="teamActionsGroupDropdown">
-    <%= link_to 'Edit', edit_team_path(@team), class: 'dropdown-item' %>
-    <%= delete_team_link @team, css_class: 'dropdown-item' %>
+<% if can? :edit, @team %>
+  <div class="btn-group float-right" role="group" aria-label="Team actions">
+    <button id="teamActionsGroupDropdown" type="button" class="btn btn-outline-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      Actions
+    </button>
+    <div class="dropdown-menu dropdown-menu-right" aria-labelledby="teamActionsGroupDropdown">
+      <%= link_to 'Edit', edit_team_path(@team), class: 'dropdown-item' %>
+      <%= delete_team_link @team, css_class: 'dropdown-item' %>
+    </div>
   </div>
-</div>
+<% end %>
 
 <h1>
   <%= team_icon %>
@@ -30,7 +32,7 @@
 
 <ul class="nav nav-tabs" role="tablist">
   <li class="nav-item">
-    <a class="nav-link active" id="projects-tab" data-toggle="tab" href="#spaces" role="tab" aria-controls="projects" aria-selected="true">Spaces</a>
+    <a class="nav-link active" id="spaces-tab" data-toggle="tab" href="#spaces" role="tab" aria-controls="spaces" aria-selected="true">Spaces</a>
   </li>
   <li class="nav-item">
     <a class="nav-link" id="people-tab" data-toggle="tab" href="#people" role="tab" aria-controls="people" aria-selected="false">People</a>
@@ -38,7 +40,7 @@
 </ul>
 
 <div class="tab-content border border-top-0">
-  <div class="tab-pane active" id="projects" role="tabpanel" aria-labelledby="projects-tab">
+  <div class="tab-pane active" id="spaces" role="tabpanel" aria-labelledby="spaces-tab">
     <% if @team.projects.count.zero? %>
       <div class="p-3 border-bottom">
         <div class="card bg-light p-3 text-center">
@@ -75,12 +77,14 @@
   </div>
 
   <div class="tab-pane" id="people" role="tabpanel" aria-labelledby="people-tab">
-    <div id="add-user-to-team" style="min-height: 82px;">
-      <add-user-to-team
-        team-id="<%= @team.id -%>"
-        team-url="<%= team_path(@team, anchor: 'people') -%>"
-      ></add-user-to-team>
-    </div>
+    <% if can? :edit, @team %>
+      <div id="add-user-to-team" class="border-bottom" style="min-height: 82px;">
+        <add-user-to-team
+          team-id="<%= @team.id -%>"
+          team-url="<%= team_path(@team, anchor: 'people') -%>"
+        ></add-user-to-team>
+      </div>
+    <% end %>
 
     <% if @team.members.count.zero? %>
       <p class="none-text text-center p-3 mb-0">

--- a/spec/factories/team_memberships.rb
+++ b/spec/factories/team_memberships.rb
@@ -1,4 +1,10 @@
 FactoryBot.define do
   factory :team_membership do
+    team
+    user
+
+    trait :admin do
+      role { 'admin' }
+    end
   end
 end

--- a/spec/requests/admin/settings_spec.rb
+++ b/spec/requests/admin/settings_spec.rb
@@ -1,29 +1,25 @@
 require 'rails_helper'
 
-RSpec.describe 'Admin - Tasks', type: :request do
-  describe 'new - GET /admin/tasks/new' do
-    let :make_request do
-      get new_admin_task_path(type: 'CreateKubeCluster', cluster_creator: 'gke')
-    end
-
+RSpec.describe 'Admin - Settings', type: :request do
+  describe 'show - GET /admin/settings' do
     it_behaves_like 'unauthenticated not allowed' do
       before do
-        make_request
+        get admin_settings_path
       end
     end
 
     it_behaves_like 'authenticated' do
       it_behaves_like 'not a hub admin so not allowed' do
         before do
-          make_request
+          get admin_settings_path
         end
       end
 
       it_behaves_like 'a hub admin' do
-        it 'loads the new admin task page' do
-          make_request
+        it 'loads the admin settings page' do
+          get admin_settings_path
           expect(response).to be_successful
-          expect(response).to render_template(:new)
+          expect(response).to render_template(:show)
         end
       end
     end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 RSpec.describe 'Projects', type: :request do
   include_context 'time helpers'
 
+  before do
+    # Create some other projects to ensure we have a broader pool of data
+    @other_projects = create_list :project, 2
+    @other_teams = @other_projects.map(&:team)
+  end
+
   describe 'index - GET /spaces' do
     it_behaves_like 'unauthenticated not allowed' do
       before do
@@ -12,7 +18,10 @@ RSpec.describe 'Projects', type: :request do
 
     it_behaves_like 'authenticated' do
       before do
-        @projects = create_list(:project, 3).sort_by(&:name)
+        @projects = (
+          create_list(:project, 3) +
+          @other_projects
+        ).sort_by(&:name)
       end
 
       it 'loads the projects index page' do
@@ -39,20 +48,48 @@ RSpec.describe 'Projects', type: :request do
       let(:activity_service) { instance_double('ActivityService') }
 
       before do
-        expect(ActivityService).to receive(:new)
+        allow(ActivityService).to receive(:new)
           .and_return(activity_service)
-        expect(activity_service).to receive(:for_project)
+        allow(activity_service).to receive(:for_project)
           .with(@project)
           .and_return([])
       end
 
-      it 'loads the project page' do
-        get project_path(@project)
+      it_behaves_like 'not a hub admin so not allowed' do
+        before do
+          get project_path(@project)
+        end
+      end
+
+      def expect_project_show_page(project)
+        get project_path(project)
         expect(response).to be_successful
         expect(response).to render_template(:show)
-        expect(assigns(:project)).to eq @project
+        expect(assigns(:project)).to eq project
         expect(assigns(:grouped_resources)).to be_present
         expect(assigns(:activity)).to eq []
+      end
+
+      it_behaves_like 'a hub admin' do
+        it 'loads the project page' do
+          expect_project_show_page @project
+        end
+      end
+
+      context 'not a hub admin but is team member of the project\'s team' do
+        before do
+          create :team_membership, team: @project.team, user: current_user
+        end
+
+        it 'loads the project page' do
+          expect_project_show_page @project
+        end
+
+        it 'can\'t load the project page for a different project' do
+          get project_path(@other_projects.first)
+          expect(response).to redirect_to root_path
+          expect(flash[:alert]).not_to be_empty
+        end
       end
     end
   end
@@ -65,25 +102,48 @@ RSpec.describe 'Projects', type: :request do
     end
 
     it_behaves_like 'authenticated' do
-      context 'when no teams exist' do
-        it 'redirects to the home page with a warning flash message' do
-          get new_project_path
-          expect(response).to redirect_to(root_path)
-          expect(flash[:warning]).not_to be_empty
+      def expect_new_project_page(allowed_teams)
+        get new_project_path
+        expect(response).to be_successful
+        expect(response).to render_template(:new)
+        expect(assigns(:project)).to be_a Project
+        expect(assigns(:project)).to be_new_record
+        expect(assigns(:teams)).to match_array allowed_teams
+      end
+
+      it_behaves_like 'a hub admin' do
+        it 'loads the new project page' do
+          expect_new_project_page @other_teams
         end
       end
 
-      context 'when teams do exist' do
-        before do
-          create_list :team, 3
+      context 'not a hub admin' do
+        context 'is not in any teams' do
+          it 'redirects to the home page with a warning flash message' do
+            get new_project_path
+            expect(response).to redirect_to(root_path)
+            expect(flash[:warning]).not_to be_empty
+          end
         end
 
-        it 'loads the new project page' do
-          get new_project_path
-          expect(response).to be_successful
-          expect(response).to render_template(:new)
-          expect(assigns(:project)).to be_a Project
-          expect(assigns(:project)).to be_new_record
+        context 'is in a team' do
+          let!(:team) { create :team }
+
+          before do
+            create :team_membership, team: team, user: current_user
+          end
+
+          it 'loads the new project page' do
+            expect_new_project_page([team])
+          end
+
+          context 'but a different team is specified in the query param' do
+            it 'can\'t load the new project page' do
+              get new_project_path(team_id: @other_teams.first.id)
+              expect(response).to redirect_to root_path
+              expect(flash[:alert]).not_to be_empty
+            end
+          end
         end
       end
     end
@@ -101,11 +161,61 @@ RSpec.describe 'Projects', type: :request do
     end
 
     it_behaves_like 'authenticated' do
-      it 'loads the edit project page' do
-        get edit_project_path(@project)
+      def expect_edit_project_page(project, allowed_teams)
+        get edit_project_path(project)
         expect(response).to be_successful
         expect(response).to render_template(:edit)
-        expect(assigns(:project)).to eq @project
+        expect(assigns(:project)).to eq project
+        expect(assigns(:teams)).to match_array allowed_teams
+      end
+
+      def expect_access_denied(project)
+        get edit_project_path(project)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).not_to be_empty
+      end
+
+      it_behaves_like 'a hub admin' do
+        it 'loads the edit project page' do
+          expect_edit_project_page @project, [@project.team] + @other_teams
+        end
+      end
+
+      context 'not a hub admin' do
+        context 'is not in any teams' do
+          it 'redirects to the home page with a warning flash message' do
+            get edit_project_path(@project)
+            expect(response).to redirect_to(root_path)
+            expect(flash[:warning]).not_to be_empty
+          end
+        end
+
+        context 'is in the project\'s team' do
+          before do
+            create :team_membership, team: @project.team, user: current_user
+          end
+
+          it 'loads the edit project page' do
+            expect_edit_project_page(@project, [@project.team])
+          end
+        end
+
+        context 'is in a different team' do
+          let(:other_project) { @other_projects.first }
+          let(:other_team) { other_project.team }
+
+          before do
+            create :team_membership, team: other_team, user: current_user
+          end
+
+          it 'can\'t load the edit project page for the project' do
+            expect_access_denied @project
+          end
+
+          it 'can still load the edit page for a project in this different team' do
+            expect_edit_project_page(other_project, [other_team])
+          end
+        end
       end
     end
   end
@@ -129,42 +239,95 @@ RSpec.describe 'Projects', type: :request do
     end
 
     it_behaves_like 'authenticated' do
-      context 'with valid params' do
-        it 'creates a new Project with the given params and redirects to the project page' do
-          expect do
-            post projects_path, params: { project: params }
-            project = assigns(:project)
-            expect(response).to redirect_to(project)
-            expect(project).to be_persisted
-            expect(project.team).to eq team
-            expect(project.name).to eq params[:name]
-            expect(project.slug).to eq params[:slug]
-            expect(project.description).to eq params[:description]
-            expect(project.created_at.to_i).to eq now.to_i
-          end.to change { Project.count }.by(1)
+      def expect_project_create(params)
+        expect do
+          post projects_path, params: { project: params }
+        end.to change { Project.count }.by(1)
+
+        project = assigns(:project)
+        expect(response).to redirect_to(project)
+        expect(project).to be_persisted
+        expect(project.team_id).to eq params[:team_id]
+        expect(project.name).to eq params[:name]
+        expect(project.slug).to eq params[:slug]
+        expect(project.description).to eq params[:description]
+        expect(project.created_at.to_i).to eq now.to_i
+
+        audit = project.audits.order(:created_at).last
+        expect(audit.action).to eq 'create'
+        expect(audit.associated_id).to eq params[:team_id]
+        expect(audit.user_email).to eq auth_email
+        expect(audit.created_at.to_i).to eq now.to_i
+      end
+
+      def expect_access_denied(params)
+        expect do
+          post projects_path, params: { project: params }
+        end.not_to change(Project, :count)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).not_to be_empty
+      end
+
+      it_behaves_like 'a hub admin' do
+        context 'with valid params' do
+          it 'creates a new project with the given params and logs and audit and redirects to the project page' do
+            expect_project_create params
+          end
         end
 
-        it 'logs an Audit' do
-          post projects_path, params: { project: params }
-          project = assigns(:project)
-          audit = project.audits.order(:created_at).last
-          expect(audit.action).to eq 'create'
-          expect(audit.associated).to eq team
-          expect(audit.user_email).to eq auth_email
-          expect(audit.created_at.to_i).to eq now.to_i
+        context 'with invalid params' do
+          it 'loads the new page with errors' do
+            expect do
+              post projects_path, params: { project: { name: nil, slug: '1 2 3' } }
+            end.not_to change(Project, :count)
+
+            expect(response).to be_successful
+            expect(response).to render_template(:new)
+            project = assigns(:project)
+            expect(project).not_to be_persisted
+            expect(project.errors).to_not be_empty
+            expect(project.errors[:name]).to be_present
+            expect(project.errors[:slug]).to be_present
+            expect(assigns(:teams)).to match_array([team] + @other_teams)
+          end
         end
       end
 
-      context 'with invalid params' do
-        it 'loads the new page with errors' do
-          post projects_path, params: { project: { name: nil, slug: '1 2 3' } }
-          expect(response).to be_successful
-          expect(response).to render_template(:new)
-          project = assigns(:project)
-          expect(project).not_to be_persisted
-          expect(project.errors).to_not be_empty
-          expect(project.errors[:name]).to be_present
-          expect(project.errors[:slug]).to be_present
+      context 'not a hub admin' do
+        context 'is not in any teams' do
+          it 'redirects to the home page with a warning flash message' do
+            expect do
+              post projects_path, params: { project: params }
+            end.not_to change(Project, :count)
+            expect(response).to redirect_to(root_path)
+            expect(flash[:warning]).not_to be_empty
+          end
+        end
+
+        context 'is in the team specified in the input params' do
+          before do
+            create :team_membership, team: team, user: current_user
+          end
+
+          it 'creates a new project with the given params and logs and audit and redirects to the project page' do
+            expect_project_create params
+          end
+        end
+
+        context 'is in a different team to the one specified in the input params' do
+          let(:other_team) { @other_teams.first }
+
+          before do
+            create :team_membership, team: other_team, user: current_user
+          end
+
+          it 'can\'t create a project within the specified team' do
+            expect_access_denied params
+          end
+
+          it 'can still create a project within this different team' do
+            expect_project_create params.merge(team_id: other_team.id)
+          end
         end
       end
     end
@@ -189,46 +352,98 @@ RSpec.describe 'Projects', type: :request do
     end
 
     it_behaves_like 'authenticated' do
-      context 'with valid params' do
-        it 'updates the existing Project with the given params and redirects to the project page' do
-          expect do
-            move_time_to 1.minute.from_now
+      def expect_project_update(project, params)
+        move_time_to 1.minute.from_now
+
+        expect do
+          put project_path(project), params: { project: params }
+        end.not_to change(Project, :count)
+
+        updated_project = Project.find project.id
+
+        expect(response).to redirect_to(updated_project)
+        expect(assigns(:project)).to eq updated_project
+        expect(updated_project.name).to eq params[:name]
+        expect(updated_project.description).to eq params[:description]
+        expect(updated_project.updated_at.to_i).to eq now.to_i
+
+        audit = updated_project.audits.order(:created_at).last
+        expect(audit.action).to eq 'update'
+        expect(audit.user_email).to eq auth_email
+        expect(audit.created_at.to_i).to eq now.to_i
+      end
+
+      def expect_access_denied(project, params)
+        original_name = project.name
+        put project_path(project), params: { project: params }
+        expect(Project.find(project.id).name).to eq original_name
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).not_to be_empty
+      end
+
+      it_behaves_like 'a hub admin' do
+        context 'with valid params' do
+          it 'updates the project with the given params and logs an audit and redirects to the project page' do
+            expect_project_update @project, updated_params
+          end
+        end
+
+        context 'with invalid params' do
+          it 'loads the edit page with errors' do
+            original_name = @project.name
+            put project_path(@project), params: { project: { name: nil } }
+            expect(response).to be_successful
+            expect(response).to render_template(:edit)
+            project = assigns(:project)
+            expect(project.errors).to_not be_empty
+            expect(project.errors[:name]).to be_present
+            expect(assigns(:teams)).to match_array([@project.team] + @other_teams)
+            expect(Project.find(project.id).name).to eq original_name
+          end
+        end
+
+        it 'silently ignores changes to the slug' do
+          put project_path(@project), params: { project: { slug: 'updated-slug' } }
+          expect(Project.exists?(slug: @project.slug)).to be true
+          expect(Project.exists?(slug: 'updated-slug')).to be false
+        end
+      end
+
+      context 'not a hub admin' do
+        context 'is not in any teams' do
+          it 'redirects to the home page with a warning flash message' do
             put project_path(@project), params: { project: updated_params }
-            project = Project.find @project.id
-            expect(response).to redirect_to(project)
-            expect(assigns(:project)).to eq project
-            expect(project.name).to eq updated_params[:name]
-            expect(project.description).to eq updated_params[:description]
-            expect(project.updated_at.to_i).to eq now.to_i
-          end.to change { Project.count }.by(0)
+            expect(response).to redirect_to(root_path)
+            expect(flash[:warning]).not_to be_empty
+          end
         end
 
-        it 'logs an Audit' do
-          move_time_to 1.minute.from_now
-          put project_path(@project), params: { project: updated_params }
-          project = Project.find @project.id
-          audit = project.audits.order(:created_at).last
-          expect(audit.action).to eq 'update'
-          expect(audit.user_email).to eq auth_email
-          expect(audit.created_at.to_i).to eq now.to_i
-        end
-      end
+        context 'is in the project\'s team' do
+          before do
+            create :team_membership, team: @project.team, user: current_user
+          end
 
-      context 'with invalid params' do
-        it 'loads the edit page with errors' do
-          put project_path(@project), params: { project: { name: nil } }
-          expect(response).to be_successful
-          expect(response).to render_template(:edit)
-          project = assigns(:project)
-          expect(project.errors).to_not be_empty
-          expect(project.errors[:name]).to be_present
+          it 'updates the project with the given params and logs an audit and redirects to the project page' do
+            expect_project_update @project, updated_params
+          end
         end
-      end
 
-      it 'silently ignores changes to the slug' do
-        put project_path(@project), params: { project: { slug: 'updated-slug' } }
-        expect(Project.exists?(slug: @project.slug)).to be true
-        expect(Project.exists?(slug: 'updated-slug')).to be false
+        context 'is in a different team' do
+          let(:other_project) { @other_projects.first }
+          let(:other_team) { other_project.team }
+
+          before do
+            create :team_membership, team: other_team, user: current_user
+          end
+
+          it 'can\'t update the project' do
+            expect_access_denied @project, updated_params
+          end
+
+          it 'can still update a project within this different team' do
+            expect_project_update other_project, updated_params
+          end
+        end
       end
     end
   end
@@ -245,25 +460,80 @@ RSpec.describe 'Projects', type: :request do
     end
 
     it_behaves_like 'authenticated' do
-      it 'deletes the existing Project and redirects to the projects index page' do
-        expect do
+      it_behaves_like 'not a hub admin so not allowed' do
+        before do
           delete project_path(@project)
-          expect(Project.exists?(@project.id)).to be false
-          expect(response).to redirect_to(projects_url)
-        end.to change { Project.count }.by(-1)
+        end
       end
 
-      it 'logs an Audit' do
+      def expect_project_destroy(project)
         move_time_to 1.minute.from_now
-        delete project_path(@project)
+
+        expect do
+          delete project_path(project)
+        end.to change { Project.count }.by(-1)
+
+        expect(Project.exists?(project.id)).to be false
+        expect(response).to redirect_to(team_path(project.team.id))
+
         audit = Audit
-          .auditable_finder(@project.id, Project.name)
+          .auditable_finder(project.id, Project.name)
           .order(:created_at)
           .last
         expect(audit).not_to be nil
         expect(audit.action).to eq 'destroy'
         expect(audit.user_email).to eq auth_email
         expect(audit.created_at.to_i).to eq now.to_i
+      end
+
+      def expect_access_denied(project)
+        expect do
+          delete project_path(project)
+        end.not_to change(Project, :count)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).not_to be_empty
+        expect(Project.exists?(project.id)).to be true
+      end
+
+      it_behaves_like 'a hub admin' do
+        it 'deletes the existing project and logs an audit and redirects to the project\'s team page' do
+          expect_project_destroy @project
+        end
+      end
+
+      context 'not a hub admin' do
+        context 'is not in any teams' do
+          it 'can\'t delete the project' do
+            expect_access_denied @project
+          end
+        end
+
+        context 'is in the project\'s team' do
+          before do
+            create :team_membership, team: @project.team, user: current_user
+          end
+
+          it 'deletes the existing project and logs an audit and redirects to the project\'s team page' do
+            expect_project_destroy @project
+          end
+        end
+
+        context 'is in a different team' do
+          let(:other_project) { @other_projects.first }
+          let(:other_team) { other_project.team }
+
+          before do
+            create :team_membership, team: other_team, user: current_user
+          end
+
+          it 'can\'t delete the project' do
+            expect_access_denied @project
+          end
+
+          it 'can still delete a project within this different team' do
+            expect_project_destroy other_project
+          end
+        end
       end
     end
   end

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe 'Project resources', type: :request do
 
   before do
     @project = create :project
+
+    # Create some other projects to ensure we have a broader pool of data
+    @other_projects = create_list :project, 2
+    @other_teams = @other_projects.map(&:team)
   end
 
   shared_examples 'fails when resource type is invalid' do
@@ -47,31 +51,85 @@ RSpec.describe 'Project resources', type: :request do
     end
 
     it_behaves_like 'authenticated' do
-      let :make_request do
-        get new_project_resource_path(@project, type: resource_type)
+      def expect_new_resource_page(project, resource_type, integration)
+        get new_project_resource_path(project, type: resource_type)
+        expect(response).to be_successful
+        expect(response).to render_template(:new)
+        expect(assigns(:project)).to eq project
+        expect(assigns(:resource_type)[:id]).to eq 'CodeRepo'
+        expect(assigns(:integrations)).to eq [integration]
+        expect(assigns(:resource)).to be_a Resource
+        expect(assigns(:resource)).to be_new_record
       end
 
-      include_examples 'fails when resource type is invalid'
+      def expect_access_denied(project, resource_type)
+        get new_project_resource_path(project, type: resource_type)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).not_to be_empty
+      end
 
-      context 'with a valid resource type' do
-        let(:resource_type) { 'CodeRepo' }
+      it_behaves_like 'a hub admin' do
+        # Used in the shared examples called below
+        let :make_request do
+          get new_project_resource_path(@project, type: resource_type)
+        end
 
-        include_examples 'fails when no integrations are available for the resource type'
+        include_examples 'fails when resource type is invalid'
 
-        context 'with at least one integration available for the resource type' do
+        context 'with a valid resource type' do
+          let(:resource_type) { 'CodeRepo' }
+
+          include_examples 'fails when no integrations are available for the resource type'
+
+          context 'with at least one integration available for the resource type' do
+            let! :integration do
+              create_mocked_integration provider_id: 'git_hub'
+            end
+
+            it 'loads the new resource page' do
+              expect_new_resource_page @project, resource_type, integration
+            end
+          end
+        end
+      end
+
+      context 'not a hub admin' do
+        context 'with a valid resource type and at least on integration for the resource type' do
+          let(:resource_type) { 'CodeRepo' }
+
           let! :integration do
             create_mocked_integration provider_id: 'git_hub'
           end
 
-          it 'loads the new resource page' do
-            make_request
-            expect(response).to be_successful
-            expect(response).to render_template(:new)
-            expect(assigns(:project)).to eq @project
-            expect(assigns(:resource_type)[:id]).to eq 'CodeRepo'
-            expect(assigns(:integrations)).to eq [integration]
-            expect(assigns(:resource)).to be_a Resource
-            expect(assigns(:resource)).to be_new_record
+          it 'can\'t load the new resource page for the project' do
+            expect_access_denied @project, resource_type
+          end
+
+          context 'is in the project\'s team' do
+            before do
+              create :team_membership, team: @project.team, user: current_user
+            end
+
+            it 'loads the new resource page' do
+              expect_new_resource_page @project, resource_type, integration
+            end
+          end
+
+          context 'is in a different team' do
+            let(:other_project) { @other_projects.first }
+            let(:other_team) { other_project.team }
+
+            before do
+              create :team_membership, team: other_team, user: current_user
+            end
+
+            it 'can\'t load the new resource page for the project' do
+              expect_access_denied @project, resource_type
+            end
+
+            it 'can still load the new resource page for a project in this different team' do
+              expect_new_resource_page other_project, resource_type, integration
+            end
           end
         end
       end
@@ -92,89 +150,155 @@ RSpec.describe 'Project resources', type: :request do
     end
 
     it_behaves_like 'authenticated' do
-      let :make_request do
-        post project_resources_path(@project, type: resource_type), params: { resource: params }
+      def expect_project_create(project, resource_type, integration, params)
+        resource_provisioning_service = instance_double('ResourceProvisioningService')
+        expect(ResourceProvisioningService).to receive(:new)
+          .and_return(resource_provisioning_service)
+        expect(resource_provisioning_service).to receive(:request_create)
+
+        expect do
+          post project_resources_path(project, type: resource_type), params: { resource: params }
+        end.to change { Resource.count }.by(1)
+
+        expect(response).to redirect_to(project_path(project, autorefresh: true))
+
+        resource = assigns(:resource)
+        expect(resource).to be_persisted
+        expect(resource).to be_a Resources::CodeRepo
+        expect(resource.integration).to eq integration
+        expect(resource.requested_by).to eq current_user
+        expect(resource.name).to eq params[:name]
+        expect(resource.created_at.to_i).to eq now.to_i
+        expect(resource.template_url).to eq params[:git_hub][:template_url]
+
+        audit = resource.audits.order(:created_at).last
+        expect(audit.action).to eq 'create'
+        expect(audit.associated).to eq project
+        expect(audit.user_email).to eq auth_email
+        expect(audit.created_at.to_i).to eq now.to_i
       end
 
-      include_examples 'fails when resource type is invalid'
+      def expect_access_denied(project, resource_type, params)
+        expect do
+          post project_resources_path(project, type: resource_type), params: { resource: params }
+        end.not_to change(Resource, :count)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).not_to be_empty
+      end
 
-      context 'with a valid resource type' do
-        let(:resource_type) { 'CodeRepo' }
+      it_behaves_like 'a hub admin' do
+        # Used in the shared examples called below
+        let :make_request do
+          post project_resources_path(@project, type: resource_type), params: { resource: params }
+        end
 
-        include_examples 'fails when no integrations are available for the resource type'
+        include_examples 'fails when resource type is invalid'
 
-        context 'with at least one integration available for the resource type' do
+        context 'with a valid resource type' do
+          let(:resource_type) { 'CodeRepo' }
+
+          include_examples 'fails when no integrations are available for the resource type'
+
+          context 'with at least one integration available for the resource type' do
+            let! :integration do
+              create_mocked_integration provider_id: 'git_hub'
+            end
+
+            context 'with valid params' do
+              let :params do
+                {
+                  type: "Resources::#{resource_type}",
+                  integration_id: integration.id,
+                  name: 'foo',
+                  git_hub: {
+                    template_url: 'template_url'
+                  }
+                }
+              end
+
+              it 'creates a new resource with the given params, requests creation, logs an audit and redirects to the project page' do
+                expect_project_create @project, resource_type, integration, params
+              end
+            end
+
+            context 'with invalid params' do
+              let :params do
+                {
+                  type: 'Resources::CodeRepo',
+                  integration_id: nil,
+                  name: 'Invalid Name'
+                }
+              end
+
+              before do
+                expect(ResourceProvisioningService).to receive(:new).never
+              end
+
+              it 'loads the new page with errors' do
+                expect do
+                  make_request
+                end.not_to change(Resource, :count)
+
+                expect(response).to be_successful
+                expect(response).to render_template(:new)
+                resource = assigns(:resource)
+                expect(resource).not_to be_persisted
+                expect(resource.errors).to_not be_empty
+                expect(resource.errors[:integration]).to be_present
+                expect(resource.errors[:name]).to be_present
+              end
+            end
+          end
+        end
+      end
+
+      context 'not a hub admin' do
+        context 'with a valid resource type and at least on integration for the resource type' do
+          let(:resource_type) { 'CodeRepo' }
+
           let! :integration do
             create_mocked_integration provider_id: 'git_hub'
           end
 
-          context 'with valid params' do
-            let :params do
-              {
-                type: 'Resources::CodeRepo',
-                integration_id: integration.id,
-                name: 'foo',
-                git_hub: {
-                  template_url: 'template_url'
-                }
+          let :params do
+            {
+              type: "Resources::#{resource_type}",
+              integration_id: integration.id,
+              name: 'foo',
+              git_hub: {
+                template_url: 'template_url'
               }
-            end
+            }
+          end
 
+          it 'can\'t create a resource within the specified project' do
+            expect_access_denied @project, resource_type, params
+          end
+
+          context 'is in the project\'s team' do
             before do
-              resource_provisioning_service = instance_double('ResourceProvisioningService')
-              expect(ResourceProvisioningService).to receive(:new)
-                .and_return(resource_provisioning_service)
-              expect(resource_provisioning_service).to receive(:request_create)
+              create :team_membership, team: @project.team, user: current_user
             end
 
-            it 'creates a new Resource with the given params, requests creation and redirects to the project page' do
-              expect do
-                make_request
-                expect(response).to redirect_to(project_path(@project, autorefresh: true))
-                resource = assigns(:resource)
-                expect(resource).to be_persisted
-                expect(resource).to be_a Resources::CodeRepo
-                expect(resource.integration).to eq integration
-                expect(resource.requested_by).to eq current_user
-                expect(resource.name).to eq params[:name]
-                expect(resource.created_at.to_i).to eq now.to_i
-                expect(resource.template_url).to eq 'template_url'
-              end.to change { Resource.count }.by(1)
-            end
-
-            it 'logs an Audit' do
-              make_request
-              resource = assigns(:resource)
-              audit = resource.audits.order(:created_at).last
-              expect(audit.action).to eq 'create'
-              expect(audit.associated).to eq @project
-              expect(audit.user_email).to eq auth_email
-              expect(audit.created_at.to_i).to eq now.to_i
+            it 'creates a new resource with the given params, requests creation, logs an audit and redirects to the project page' do
+              expect_project_create @project, resource_type, integration, params
             end
           end
 
-          context 'with invalid params' do
-            let :params do
-              {
-                type: 'Resources::CodeRepo',
-                integration_id: nil,
-                name: 'Invalid Name'
-              }
-            end
+          context 'is in a different team' do
+            let(:other_project) { @other_projects.first }
+            let(:other_team) { other_project.team }
 
             before do
-              expect(ResourceProvisioningService).to receive(:new).never
+              create :team_membership, team: other_team, user: current_user
             end
 
-            it 'loads the new page with errors' do
-              make_request
-              expect(response).to be_successful
-              expect(response).to render_template(:new)
-              resource = assigns(:resource)
-              expect(resource).not_to be_persisted
-              expect(resource.errors).to_not be_empty
-              expect(resource.errors[:integration]).to be_present
-              expect(resource.errors[:name]).to be_present
+            it 'can\'t create a resource within the specified project' do
+              expect_access_denied @project, resource_type, params
+            end
+
+            it 'can still load the new resource page for a project in this different team' do
+              expect_project_create other_project, resource_type, integration, params
             end
           end
         end
@@ -206,15 +330,76 @@ RSpec.describe 'Project resources', type: :request do
     end
 
     it_behaves_like 'authenticated' do
-      it 'requests deletion of the resource' do
+      it_behaves_like 'not a hub admin so not allowed' do
+        before do
+          delete project_resource_path(@project, resource)
+        end
+      end
+
+      def expect_resource_deletion_request(resource)
         expect(resource_provisioning_service).to receive(:request_delete)
           .with(resource)
 
         expect do
-          delete project_resource_path(@project, resource)
+          delete project_resource_path(resource.project, resource)
         end.not_to change(Resource, :count)
 
-        expect(response).to redirect_to(project_path(@project, autorefresh: true))
+        expect(response).to redirect_to(project_path(resource.project, autorefresh: true))
+      end
+
+      def expect_access_denied(resource)
+        expect(resource_provisioning_service).to receive(:request_delete)
+          .with(resource)
+          .never
+        delete project_resource_path(resource.project, resource)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).not_to be_empty
+        expect(Resource.find(resource.id)).not_to eq Resource.statuses[:deleting]
+      end
+
+      it_behaves_like 'a hub admin' do
+        it 'requests deletion of the resource' do
+          expect_resource_deletion_request resource
+        end
+
+        context 'with mismatched project and resource provided' do
+          it 'raises a RecordNotFound error' do
+            expect do
+              delete project_resource_path(@other_projects.first, resource)
+            end.to raise_error(ActiveRecord::RecordNotFound)
+            expect(Resource.find(resource.id)).not_to eq Resource.statuses[:deleting]
+          end
+        end
+      end
+
+      context 'not a hub admin' do
+        context 'is in the project\'s team' do
+          before do
+            create :team_membership, team: @project.team, user: current_user
+          end
+
+          it 'requests deletion of the resource' do
+            expect_resource_deletion_request resource
+          end
+        end
+
+        context 'is in a different team' do
+          let(:other_project) { @other_projects.first }
+          let(:other_team) { other_project.team }
+
+          before do
+            create :team_membership, team: other_team, user: current_user
+          end
+
+          it 'can\'t request deletion of a resource within the specified project' do
+            expect_access_denied resource
+          end
+
+          it 'can still request deletion of a resource in this different project' do
+            resource = create :code_repo, project: other_project, integration: integration
+            expect_resource_deletion_request resource
+          end
+        end
       end
     end
   end
@@ -227,25 +412,74 @@ RSpec.describe 'Project resources', type: :request do
     end
 
     it_behaves_like 'authenticated' do
-      context 'when project already has resources' do
+      it_behaves_like 'not a hub admin so not allowed' do
         before do
-          integration = create_mocked_integration
-          create :code_repo, project: @project, integration: integration
-        end
-
-        it 'calls the ProjectResourcesBootstrapService as expected but redirects back to home' do
+          expect(ProjectResourcesBootstrapService).to receive(:new).never
           get bootstrap_project_resources_path(@project)
-          expect(response).to redirect_to(root_path)
-          expect(flash[:warning]).not_to be_empty
         end
       end
 
-      context 'when project has no resources' do
-        it 'calls the ProjectResourcesBootstrapService as expected and loads the page' do
-          get bootstrap_project_resources_path(@project)
-          expect(response).to be_successful
-          expect(response).to render_template(:prepare_bootstrap)
-          expect(assigns(:prepare_results)).to be_present
+      def expect_prepare_bootstrap_page(project)
+        get bootstrap_project_resources_path(project)
+        expect(response).to be_successful
+        expect(response).to render_template(:prepare_bootstrap)
+        expect(assigns(:prepare_results)).to be_present
+      end
+
+      def expect_access_denied(project)
+        expect(ProjectResourcesBootstrapService).to receive(:new).never
+        get bootstrap_project_resources_path(project)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).not_to be_empty
+      end
+
+      it_behaves_like 'a hub admin' do
+        context 'when project already has resources' do
+          before do
+            integration = create_mocked_integration
+            create :code_repo, project: @project, integration: integration
+          end
+
+          it 'redirects back to home' do
+            get bootstrap_project_resources_path(@project)
+            expect(response).to redirect_to(root_path)
+            expect(flash[:warning]).not_to be_empty
+          end
+        end
+
+        context 'when project has no resources' do
+          it 'loads the prepare_bootstrap page' do
+            expect_prepare_bootstrap_page @project
+          end
+        end
+      end
+
+      context 'not a hub admin' do
+        context 'is in the project\'s team' do
+          before do
+            create :team_membership, team: @project.team, user: current_user
+          end
+
+          it 'loads the prepare_bootstrap page' do
+            expect_prepare_bootstrap_page @project
+          end
+        end
+
+        context 'is in a different team' do
+          let(:other_project) { @other_projects.first }
+          let(:other_team) { other_project.team }
+
+          before do
+            create :team_membership, team: other_team, user: current_user
+          end
+
+          it 'can\'t load the prepare_bootstrap page for the project' do
+            expect_access_denied @project
+          end
+
+          it 'can still load the prepare_bootstrap page for this different project' do
+            expect_prepare_bootstrap_page other_project
+          end
         end
       end
     end
@@ -259,18 +493,65 @@ RSpec.describe 'Project resources', type: :request do
     end
 
     it_behaves_like 'authenticated' do
-      before do
+      it_behaves_like 'not a hub admin so not allowed' do
+        before do
+          expect(ProjectResourcesBootstrapService).to receive(:new).never
+          post bootstrap_project_resources_path(@project)
+        end
+      end
+
+      def expect_bootstrap(project)
         project_bootstrap_service = instance_double('ProjectResourcesBootstrapService')
         expect(ProjectResourcesBootstrapService).to receive(:new)
-          .with(@project)
+          .with(project)
           .and_return(project_bootstrap_service)
         expect(project_bootstrap_service).to receive(:bootstrap)
           .with(requested_by: current_user)
+
+        post bootstrap_project_resources_path(project)
+        expect(response).to redirect_to(project_path(project, autorefresh: true))
       end
 
-      it 'calls the ProjectResourcesBootstrapService as expected and redirects to the project page' do
-        post bootstrap_project_resources_path(@project)
-        expect(response).to redirect_to(project_path(@project, autorefresh: true))
+      def expect_access_denied(project)
+        expect(ProjectResourcesBootstrapService).to receive(:new).never
+        get bootstrap_project_resources_path(project)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).not_to be_empty
+      end
+
+      it_behaves_like 'a hub admin' do
+        it 'bootstraps resources and redirects to the project page' do
+          expect_bootstrap @project
+        end
+      end
+
+      context 'not a hub admin' do
+        context 'is in the project\'s team' do
+          before do
+            create :team_membership, team: @project.team, user: current_user
+          end
+
+          it 'bootstraps resources and redirects to the project page' do
+            expect_bootstrap @project
+          end
+        end
+
+        context 'is in a different team' do
+          let(:other_project) { @other_projects.first }
+          let(:other_team) { other_project.team }
+
+          before do
+            create :team_membership, team: other_team, user: current_user
+          end
+
+          it 'can\'t boostrap resources for the project' do
+            expect_access_denied @project
+          end
+
+          it 'can still bootstrap resources for this different project' do
+            expect_bootstrap other_project
+          end
+        end
       end
     end
   end

--- a/spec/requests/team_memberships_spec.rb
+++ b/spec/requests/team_memberships_spec.rb
@@ -1,0 +1,198 @@
+require 'rails_helper'
+
+RSpec.describe 'Team Memberships', type: :request do
+  include_context 'time helpers'
+
+  before do
+    @team = create :team
+    @user = create :user
+
+    # Create some other teams to ensure we have a broader pool of data
+    @other_teams = create_list :team, 2
+  end
+
+  describe 'update - PUT /teams/:team_id/memberships/:id' do
+    it_behaves_like 'unauthenticated not allowed' do
+      before do
+        put team_membership_path(@team, @user)
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+      it_behaves_like 'not a hub admin so not allowed' do
+        before do
+          put team_membership_path(@team, @user)
+        end
+      end
+
+      def expect_team_membership_create_or_update(team, user, role: nil, expect_new: true)
+        move_time_to 1.minute.from_now
+
+        put team_membership_path(team, user, role: role)
+        expect(response).to redirect_to(team_path(team, anchor: 'people'))
+        team_membership = team.memberships.where(user_id: user.id).first
+        expect(team_membership).not_to be nil
+        expect(team_membership.role).to eq role
+        expect(assigns(:team_membership)).to eq team_membership
+
+        audit = team_membership.audits.order(:created_at).last
+        action = expect_new ? 'create' : 'update'
+        expect(audit.action).to eq action
+        expect(audit.user_email).to eq auth_email
+        expect(audit.created_at.to_i).to eq now.to_i
+      end
+
+      def expect_access_denied(team, user)
+        put team_membership_path(team, user)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).not_to be_empty
+      end
+
+      it_behaves_like 'a hub admin' do
+        context 'when membership does not exist yet' do
+          it 'creates the new team membership and logs an audit' do
+            expect(@team.memberships.exists?(user_id: @user.id)).to be false
+            expect_team_membership_create_or_update @team, @user, role: 'admin'
+          end
+        end
+
+        context 'when membership exists and a role change is made' do
+          before do
+            create :team_membership, team: @team, user: @user
+          end
+
+          it 'updates the role of the existing team membership' do
+            expect(@team.memberships.exists?(user_id: @user.id)).to be true
+            expect_team_membership_create_or_update @team, @user, role: 'admin', expect_new: false
+          end
+        end
+      end
+
+      context 'not a hub admin but is team member of the team' do
+        before do
+          create :team_membership, team: @team, user: current_user
+        end
+
+        it 'can\'t create or update a team membership within the team' do
+          expect_access_denied @team, @user
+        end
+
+        it 'can\'t create or update a team membership within a different team' do
+          expect_access_denied @other_teams.first, @user
+        end
+      end
+
+      context 'not a hub admin but is team admin of the team' do
+        before do
+          create :team_membership, :admin, team: @team, user: current_user
+        end
+
+        it 'can create and update a team membership for the team' do
+          expect(@team.memberships.exists?(user_id: @user.id)).to be false
+          expect_team_membership_create_or_update @team, @user, role: nil
+
+          expect(@team.memberships.exists?(user_id: @user.id)).to be true
+          expect_team_membership_create_or_update @team, @user, role: 'admin', expect_new: false
+        end
+
+        it 'can\'t create or update a team membership within a different team' do
+          expect_access_denied @other_teams.first, @user
+        end
+      end
+    end
+  end
+
+  describe 'destroy - DELETE /teams/:team_id/memberships/:id' do
+    it_behaves_like 'unauthenticated not allowed' do
+      before do
+        delete team_membership_path(@team, @user)
+      end
+    end
+
+    it_behaves_like 'authenticated' do
+      it_behaves_like 'not a hub admin so not allowed' do
+        before do
+          delete team_membership_path(@team, @user)
+        end
+      end
+
+      def expect_team_membership_destroy(team, user, expect_audit: true)
+        move_time_to 1.minute.from_now
+
+        delete team_membership_path(team, user)
+
+        expect(response).to redirect_to(team_path(team, anchor: 'people'))
+        expect(team.memberships.exists?(user_id: user.id)).to be false
+
+        return unless expect_audit
+
+        audit = team.associated_audits.order(:created_at).last
+        expect(audit).not_to be nil
+        expect(audit.action).to eq 'destroy'
+        expect(audit.user_email).to eq auth_email
+        expect(audit.created_at.to_i).to eq now.to_i
+      end
+
+      def expect_access_denied(team, user)
+        expect do
+          delete team_membership_path(team, user)
+        end.not_to change(TeamMembership, :count)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).not_to be_empty
+      end
+
+      it_behaves_like 'a hub admin' do
+        context 'when membership does not exist yet' do
+          it 'doesn\'t do anything' do
+            expect(@team.memberships.exists?(user_id: @user.id)).to be false
+            expect_team_membership_destroy @team, @user, expect_audit: false
+          end
+        end
+
+        context 'when membership exists' do
+          before do
+            create :team_membership, team: @team, user: @user
+          end
+
+          it 'deletes the existing team membership' do
+            expect(@team.memberships.exists?(user_id: @user.id)).to be true
+            expect_team_membership_destroy @team, @user, expect_audit: true
+          end
+        end
+      end
+
+      context 'not a hub admin but is team member of the team' do
+        before do
+          create :team_membership, team: @team, user: current_user
+
+          create :team_membership, team: @team, user: @user
+        end
+
+        it 'can\'t delete a team membership within the team' do
+          expect_access_denied @team, @user
+        end
+
+        it 'can\'t delete a team membership within a different team' do
+          expect_access_denied @other_teams.first, @user
+        end
+      end
+
+      context 'not a hub admin but is team admin of the team' do
+        before do
+          create :team_membership, :admin, team: @team, user: current_user
+
+          create :team_membership, team: @team, user: @user
+        end
+
+        it 'can delete a team membership for the team' do
+          expect(@team.memberships.exists?(user_id: @user.id)).to be true
+          expect_team_membership_destroy @team, @user, expect_audit: true
+        end
+
+        it 'can\'t create or update a team membership within a different team' do
+          expect_access_denied @other_teams.first, @user
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/teams_spec.rb
+++ b/spec/requests/teams_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 RSpec.describe 'Teams', type: :request do
   include_context 'time helpers'
 
+  before do
+    # Create some other teams to ensure we have a broader pool of data
+    @other_teams = create_list :team, 2
+  end
+
   describe 'index - GET /teams' do
     it_behaves_like 'unauthenticated not allowed' do
       before do
@@ -12,7 +17,10 @@ RSpec.describe 'Teams', type: :request do
 
     it_behaves_like 'authenticated' do
       before do
-        @teams = create_list(:team, 3).sort_by(&:name)
+        @teams = (
+          create_list(:team, 3) +
+          @other_teams
+        ).sort_by(&:name)
       end
 
       it 'loads the teams index page' do
@@ -36,11 +44,39 @@ RSpec.describe 'Teams', type: :request do
     end
 
     it_behaves_like 'authenticated' do
-      it 'loads the team page' do
-        get team_path(@team)
+      it_behaves_like 'not a hub admin so not allowed' do
+        before do
+          get team_path(@team)
+        end
+      end
+
+      def expect_team_show_page(team)
+        get team_path(team)
         expect(response).to be_successful
         expect(response).to render_template(:show)
-        expect(assigns(:team)).to eq @team
+        expect(assigns(:team)).to eq team
+      end
+
+      it_behaves_like 'a hub admin' do
+        it 'loads the team page' do
+          expect_team_show_page @team
+        end
+      end
+
+      context 'not a hub admin but is team member of the team' do
+        before do
+          create :team_membership, team: @team, user: current_user
+        end
+
+        it 'loads the team page' do
+          expect_team_show_page @team
+        end
+
+        it 'can\'t load the team page for a different team' do
+          get team_path(@other_teams.first)
+          expect(response).to redirect_to root_path
+          expect(flash[:alert]).not_to be_empty
+        end
       end
     end
   end
@@ -75,11 +111,57 @@ RSpec.describe 'Teams', type: :request do
     end
 
     it_behaves_like 'authenticated' do
-      it 'loads the edit team page' do
-        get edit_team_path(@team)
+      it_behaves_like 'not a hub admin so not allowed' do
+        before do
+          get edit_team_path(@team)
+        end
+      end
+
+      def expect_edit_team_page(team)
+        get edit_team_path(team)
         expect(response).to be_successful
         expect(response).to render_template(:edit)
-        expect(assigns(:team)).to eq @team
+        expect(assigns(:team)).to eq team
+      end
+
+      def expect_access_denied(team)
+        get edit_team_path(team)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).not_to be_empty
+      end
+
+      it_behaves_like 'a hub admin' do
+        it 'loads the edit team page' do
+          expect_edit_team_page @team
+        end
+      end
+
+      context 'not a hub admin but is team member of the team' do
+        before do
+          create :team_membership, team: @team, user: current_user
+        end
+
+        it 'can\'t load the edit team page for the team' do
+          expect_access_denied @team
+        end
+
+        it 'can\'t load the edit team page for a different team' do
+          expect_access_denied @other_teams.first
+        end
+      end
+
+      context 'not a hub admin but is team admin of the team' do
+        before do
+          create :team_membership, :admin, team: @team, user: current_user
+        end
+
+        it 'loads the edit team page' do
+          expect_edit_team_page @team
+        end
+
+        it 'can\'t load the edit team page for a different team' do
+          expect_access_denied @other_teams.first
+        end
       end
     end
   end
@@ -126,7 +208,10 @@ RSpec.describe 'Teams', type: :request do
 
       context 'with invalid params' do
         it 'loads the new page with errors' do
-          post teams_path, params: { team: { name: nil, slug: '1 2 3' } }
+          expect do
+            post teams_path, params: { team: { name: nil, slug: '1 2 3' } }
+          end.not_to change(Team, :count)
+
           expect(response).to be_successful
           expect(response).to render_template(:new)
           team = assigns(:team)
@@ -158,46 +243,88 @@ RSpec.describe 'Teams', type: :request do
     end
 
     it_behaves_like 'authenticated' do
-      context 'with valid params' do
-        it 'updates the existing Team with the given params and redirects to the team page' do
-          expect do
-            move_time_to 1.minute.from_now
-            put team_path(@team), params: { team: updated_params }
-            team = Team.find @team.id
-            expect(response).to redirect_to(team)
-            expect(assigns(:team)).to eq team
-            expect(team.name).to eq updated_params[:name]
-            expect(team.description).to eq updated_params[:description]
-            expect(team.updated_at.to_i).to eq now.to_i
-          end.to change { Team.count }.by(0)
+      def expect_team_update(team, params)
+        move_time_to 1.minute.from_now
+
+        expect do
+          put team_path(team), params: { team: params }
+        end.not_to change(Team, :count)
+
+        updated_team = Team.find team.id
+
+        expect(response).to redirect_to(updated_team)
+        expect(assigns(:team)).to eq updated_team
+        expect(updated_team.name).to eq params[:name]
+        expect(updated_team.description).to eq params[:description]
+        expect(updated_team.updated_at.to_i).to eq now.to_i
+
+        audit = updated_team.audits.order(:created_at).last
+        expect(audit.action).to eq 'update'
+        expect(audit.user_email).to eq auth_email
+        expect(audit.created_at.to_i).to eq now.to_i
+      end
+
+      def expect_access_denied(team, params)
+        original_name = team.name
+        put team_path(team), params: { team: params }
+        expect(Team.find(team.id).name).to eq original_name
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).not_to be_empty
+      end
+
+      it_behaves_like 'a hub admin' do
+        context 'with valid params' do
+          it 'updates the team with the given params and logs an audit and redirects to the team page' do
+            expect_team_update @team, updated_params
+          end
         end
 
-        it 'logs an Audit' do
-          move_time_to 1.minute.from_now
-          put team_path(@team), params: { team: updated_params }
-          team = Team.find @team.id
-          audit = team.audits.order(:created_at).last
-          expect(audit.action).to eq 'update'
-          expect(audit.user_email).to eq auth_email
-          expect(audit.created_at.to_i).to eq now.to_i
+        context 'with invalid params' do
+          it 'loads the edit page with errors' do
+            original_name = @team.name
+            put team_path(@team), params: { team: { name: nil } }
+            expect(response).to be_successful
+            expect(response).to render_template(:edit)
+            team = assigns(:team)
+            expect(team.errors).to_not be_empty
+            expect(team.errors[:name]).to be_present
+            expect(Team.find(team.id).name).to eq original_name
+          end
+        end
+
+        it 'silently ignores changes to the slug' do
+          put team_path(@team), params: { team: { slug: 'updated-slug' } }
+          expect(Team.exists?(slug: @team.slug)).to be true
+          expect(Team.exists?(slug: 'updated-slug')).to be false
         end
       end
 
-      context 'with invalid params' do
-        it 'loads the edit page with errors' do
-          put team_path(@team), params: { team: { name: nil } }
-          expect(response).to be_successful
-          expect(response).to render_template(:edit)
-          team = assigns(:team)
-          expect(team.errors).to_not be_empty
-          expect(team.errors[:name]).to be_present
+      context 'not a hub admin but is team member of the team' do
+        before do
+          create :team_membership, team: @team, user: current_user
+        end
+
+        it 'can\'t update the team' do
+          expect_access_denied @team, updated_params
+        end
+
+        it 'can\'t update a different team' do
+          expect_access_denied @other_teams.first, updated_params
         end
       end
 
-      it 'silently ignores changes to the slug' do
-        put team_path(@team), params: { team: { slug: 'updated-slug' } }
-        expect(Team.exists?(slug: @team.slug)).to be true
-        expect(Team.exists?(slug: 'updated-slug')).to be false
+      context 'not a hub admin but is team admin of the team' do
+        before do
+          create :team_membership, :admin, team: @team, user: current_user
+        end
+
+        it 'updates the team with the given params and logs an audit and redirects to the team page' do
+          expect_team_update @team, updated_params
+        end
+
+        it 'can\'t update a different team' do
+          expect_access_denied @other_teams.first, updated_params
+        end
       end
     end
   end
@@ -214,25 +341,73 @@ RSpec.describe 'Teams', type: :request do
     end
 
     it_behaves_like 'authenticated' do
-      it 'deletes the existing Team and redirects to the teams index page' do
-        expect do
+      it_behaves_like 'not a hub admin so not allowed' do
+        before do
           delete team_path(@team)
-          expect(Team.exists?(@team.id)).to be false
-          expect(response).to redirect_to(teams_url)
-        end.to change { Team.count }.by(-1)
+        end
       end
 
-      it 'logs an Audit' do
+      def expect_team_destroy(team)
         move_time_to 1.minute.from_now
-        delete team_path(@team)
+
+        expect do
+          delete team_path(team)
+        end.to change { Team.count }.by(-1)
+
+        expect(Team.exists?(team.id)).to be false
+        expect(response).to redirect_to(teams_url)
+
         audit = Audit
-          .auditable_finder(@team.id, Team.name)
+          .auditable_finder(team.id, Team.name)
           .order(:created_at)
           .last
         expect(audit).not_to be nil
         expect(audit.action).to eq 'destroy'
         expect(audit.user_email).to eq auth_email
         expect(audit.created_at.to_i).to eq now.to_i
+      end
+
+      def expect_access_denied(team)
+        expect do
+          delete team_path(team)
+        end.not_to change(Team, :count)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).not_to be_empty
+        expect(Team.exists?(team.id)).to be true
+      end
+
+      it_behaves_like 'a hub admin' do
+        it 'deletes the existing team and logs an audit and redirects to the teams index page' do
+          expect_team_destroy @team
+        end
+      end
+
+      context 'not a hub admin but is team member of the team' do
+        before do
+          create :team_membership, team: @team, user: current_user
+        end
+
+        it 'can\'t delete the team' do
+          expect_access_denied @team
+        end
+
+        it 'can\'t delete a different team' do
+          expect_access_denied @other_teams.first
+        end
+      end
+
+      context 'not a hub admin but is team admin of the team' do
+        before do
+          create :team_membership, :admin, team: @team, user: current_user
+        end
+
+        it 'deletes the existing team and logs an audit and redirects to the teams index page' do
+          expect_team_destroy @team
+        end
+
+        it 'can\'t delete a different team' do
+          expect_access_denied @other_teams.first
+        end
       end
     end
   end

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -27,6 +27,11 @@ module AuthenticationHelpers
 
   RSpec.shared_examples 'authenticated' do
     include RequestHelpersAuthOverrides
+
+    before do
+      # Reset the current_user's role in case they were made a hub admin automatically
+      current_user.update! role: User.roles[:user]
+    end
   end
 
   module RequestHelpersAuthOverrides

--- a/spec/support/hub_admin_authorization_helpers.rb
+++ b/spec/support/hub_admin_authorization_helpers.rb
@@ -1,4 +1,4 @@
-module HubAdminHelpers
+module HubAdminAuthorizationHelpers
   # The helpers here need to be used within the shared examples defined in
   # authentication_helpers, otherwise they won't work.
 
@@ -9,6 +9,7 @@ module HubAdminHelpers
 
     it 'redirects to the root page' do
       expect(response).to redirect_to root_path
+      expect(flash[:alert]).not_to be_empty
     end
   end
 


### PR DESCRIPTION
Authorization is carried out at the controller level only, with appropriate conditions in the UI to determine when to show actions/links/etc.

Specs are included to check the authorization of every endpoint.

Uses [CanCanCan](https://github.com/CanCanCommunity/cancancan) to perform the authorization.

Rules:
- Only hub admins can make/revoke hub admins
- Only hub and team admins can edit (their) teams
- Any logged in user can see the list of all teams and spaces in the hub
  - … but only ones they have access to are clickable in the UI
- Any logged in user can create a new team (and automatically becomes team admin)
- Any team member can view the team page for their teams
- Only hub and team admins can edit and delete teams
  - plus lock down UI
- Only hub and team admins can add/remove users from teams
  - plus lock down UI
- Only hub and team admins can make/revoke team admins
  - plus lock down UI
- Only hub admins and any team member can view a space page within a team
- Only hub admins and any team member can create, edit and delete a space within a team
- Only hub admins and any team member can create and delete resources within spaces in a team
- Only hub admins and any team member can run the resources bootstrap within spaces in a team
- Change hub admin controllers to now use the new authorization mechanism
- Skip authorization for:
  - All `/me` endpoints (since they always acts on the current user anyway)
  - Teams index page
  - Spaces index page
  - Healthcheck