### PR TITLE
Revamped activity streams for new Teams feature

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ gem 'typhoeus', '~> 1.3', '>= 1.3.1'
 gem 'wait', '~> 0.5.3'
 gem 'hub-clusters-creator', github: 'appvia/hub-clusters-creator', tag: 'v0.0.7'
 gem 'pg_search', '~> 2.3'
-gem 'composite_primary_keys', '~> 11.2'
 gem 'active_model_serializers', '~> 0.10.10'
 gem 'cancancan', '~> 3.0', '>= 3.0.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,8 +97,6 @@ GEM
     case_transform (0.2)
       activesupport
     coderay (1.1.2)
-    composite_primary_keys (11.2.0)
-      activerecord (~> 5.2.1)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
     crass (1.0.4)
@@ -412,7 +410,6 @@ DEPENDENCIES
   bootstrap_form (~> 4.2)
   byebug
   cancancan (~> 3.0, >= 3.0.1)
-  composite_primary_keys (~> 11.2)
   crypt_keeper (~> 2.0, >= 2.0.1)
   default_value_for (~> 3.1)
   dotenv-rails (~> 2.7.2)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,6 +2,6 @@ class HomeController < ApplicationController
   skip_authorization_check
 
   def show
-    @activity = ActivityService.new.overall
+    @activity = ActivityService.new.overall current_user
   end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -11,7 +11,9 @@ class TeamsController < ApplicationController
   end
 
   # GET /teams/1
-  def show; end
+  def show
+    @activity = ActivityService.new.for_team @team
+  end
 
   # GET /teams/new
   def new

--- a/app/models/team_membership.rb
+++ b/app/models/team_membership.rb
@@ -1,8 +1,6 @@
 class TeamMembership < ApplicationRecord
   audited associated_with: :team
 
-  self.primary_keys = :team_id, :user_id
-
   enum role: {
     admin: 'admin'
   }

--- a/app/services/activity_service.rb
+++ b/app/services/activity_service.rb
@@ -1,26 +1,108 @@
 class ActivityService
   DEFAULT_PAGE_SIZE = 20
+  DEFAULT_TIME_WINDOW = 1.month
 
-  AUDITABLE_TYPES = %w[
-    User
-    Project
-    Resource
-  ].freeze
+  # These must match what gets shown in view(s)
+  AUDITABLE_TYPES_AND_ACTIONS = {
+    'User' => %w[create update],
+    'Team' => %w[create destroy],
+    'TeamMembership' => %w[create update destroy],
+    'Project' => %w[create destroy],
+    'Resource' => %w[request_create update request_delete destroy]
+  }.freeze
 
-  def overall
-    with_defaults(Audit.all)
+  USER_FILTERED_TYPES = %w[Team Project].freeze
+
+  def overall(user)
+    user_team_ids = user.admin? ? [] : user.teams.pluck(:id)
+    user_project_ids = if user.admin?
+                         []
+                       else
+                         Project
+                           .where(team_id: user_team_ids)
+                           .pluck(:id)
+                       end
+
+    fill(DEFAULT_PAGE_SIZE) do |page, per_page|
+      items = fetch(Audit.all, page, per_page).entries
+
+      filtered_items = if user.admin?
+                         items
+                       else
+                         filter_audits(items, user_team_ids, user_project_ids)
+                       end
+
+      [
+        items.empty? || items.length < DEFAULT_PAGE_SIZE,
+        filtered_items
+      ]
+    end
+  end
+
+  def for_team(team)
+    fill(DEFAULT_PAGE_SIZE) do |page, per_page|
+      items = fetch(team.own_and_associated_audits, page, per_page).entries
+
+      [
+        items.empty? || items.length < DEFAULT_PAGE_SIZE,
+        items
+      ]
+    end
   end
 
   def for_project(project)
-    with_defaults(project.own_and_associated_audits)
+    fill(DEFAULT_PAGE_SIZE) do |page, per_page|
+      items = fetch(project.own_and_associated_audits, page, per_page).entries
+
+      [
+        items.empty? || items.length < DEFAULT_PAGE_SIZE,
+        items
+      ]
+    end
   end
 
   private
 
-  def with_defaults(scope)
-    scope
-      .where(auditable_type: AUDITABLE_TYPES)
-      .limit(DEFAULT_PAGE_SIZE)
+  def fill(size)
+    items = []
+    page = 0
+    finished = false
+
+    while items.length < size && !finished
+      page += 1
+      finished, new_items = yield page, size
+      items += new_items
+    end
+
+    items
+  end
+
+  def fetch(initial_scope, page, per_page)
+    initial_scope
+      .merge(allowed_types_query)
+      .where('created_at >= ?', DEFAULT_TIME_WINDOW.ago.utc)
+      .limit(per_page)
+      .offset((page - 1) * per_page)
       .order(created_at: :desc)
+  end
+
+  def allowed_types_query
+    conditions = AUDITABLE_TYPES_AND_ACTIONS.map do |k, v|
+      Audit.where(auditable_type: k, action: v)
+    end
+    head, *tail = conditions
+    tail.reduce(head) { |acc, q| acc.or(q) }
+  end
+
+  def filter_audits(audits, allowed_teams, allowed_projects)
+    audits.select do |a|
+      next true unless USER_FILTERED_TYPES.include?(a.auditable_type) ||
+                       USER_FILTERED_TYPES.include?(a.associated_type)
+
+      # Since we use UUIDs for IDs, we can assume a very tiny chance of clashes
+      # across different db records.
+      id = a.associated_id || a.auditable_id
+      allowed_teams.include?(id) || allowed_projects.include?(id)
+    end
   end
 end

--- a/app/views/activity/_stream.html.erb
+++ b/app/views/activity/_stream.html.erb
@@ -21,16 +21,75 @@
               <% end %>
             <% end %>
           <%- end -%>
+        <%- when 'Team' -%>
+          <%- case a.action -%>
+          <%- when 'create' -%>
+            <%= activity_entry team_icon, a.created_at do %>
+              <%= a.user_email %> created a new team
+              <%= link_to a.auditable_descriptor, team_path(a.auditable_id), class: 'text-monospace' %>
+            <% end %>
+          <%- when 'destroy' -%>
+            <%= activity_entry team_icon, a.created_at do %>
+              <%= a.user_email %> deleted team
+              <span class="text-monospace"><%= a.auditable_descriptor %></span>
+            <% end %>
+          <%- end -%>
+        <%- when 'TeamMembership' -%>
+          <%- case a.action -%>
+          <%- when 'create' -%>
+            <%= activity_entry team_icon, a.created_at do %>
+              <%= a.user_email %> added
+              <% if a.auditable.present? %>
+                user <%= a.auditable.user.email %>
+              <% else %>
+                an unknown user (probably because they've since been removed)
+              <% end %>
+              to the team
+              <%= link_to a.associated_descriptor, team_path(a.associated_id), class: 'text-monospace' %>
+              <% if a.audited_changes['role'].present? %>
+                (as <strong><%= a.audited_changes['role'] %></strong>)
+              <% end %>
+            <% end %>
+          <%- when 'update' -%>
+            <% role_change = Array(a.audited_changes['role']).flatten %>
+            <% if role_change.uniq.size == 2 %>
+              <%= activity_entry team_icon, a.created_at do %>
+                <%= a.user_email %> changed role for
+                <% if a.auditable.present? %>
+                  user <%= a.auditable.user.email %>
+                <% else %>
+                  an unknown user (probably because they've since been removed)
+                <% end %>
+                in team
+                <%= link_to a.associated_descriptor, team_path(a.associated_id), class: 'text-monospace' %>
+                from <%= role_change.first || 'regular team member' %>
+                to <strong><%= role_change.second || 'regular team member' %></strong>
+              <% end %>
+            <% end %>
+          <%- when 'destroy' -%>
+            <%= activity_entry team_icon, a.created_at do %>
+              <%= a.user_email %> removed
+              <% if a.auditable.present? %>
+                user <%= a.auditable.user.email %>
+              <% else %>
+                an unknown user (probably because they've since been removed)
+              <% end %>
+              from the team
+              <%= link_to a.associated_descriptor, team_path(a.associated_id), class: 'text-monospace' %>
+            <% end %>
+          <%- end -%>
         <%- when 'Project' -%>
           <%- case a.action -%>
           <%- when 'create' -%>
             <%= activity_entry project_icon, a.created_at do %>
-              <%= a.user_email %> created a new space:
+              <%= a.user_email %> created a new space
               <%= link_to a.auditable_descriptor, project_path(a.auditable_id), class: 'text-monospace' %>
+              within team
+              <%= link_to a.associated_descriptor, team_path(a.associated_id), class: 'text-monospace' %>
             <% end %>
           <%- when 'destroy' -%>
             <%= activity_entry project_icon, a.created_at do %>
-              <%= a.user_email %> deleted space:
+              <%= a.user_email %> deleted space
               <span class="text-monospace"><%= a.auditable_descriptor %></span>
             <% end %>
           <%- end -%>
@@ -39,16 +98,16 @@
           <%- when 'request_create' -%>
             <%= activity_entry resource_icon(a.auditable_model_name), a.created_at do %>
               <% if a.user_email %>
-                <%= a.user_email %> requested a new resource:
+                <%= a.user_email %> requested a new resource
               <% else %>
-                A new resource has been requested:
+                A new resource has been requested
               <% end %>
               <span class="font-weight-bold">
                 <%= a.auditable_descriptor %>
               </span>
               <% status = 'pending' %>
               <%= resource_status_badge status %>
-              for space:
+              for space
               <%= link_to a.associated_descriptor, project_path(a.associated_id), class: 'text-monospace' %>
             <% end %>
           <%- when 'update' -%>
@@ -62,16 +121,16 @@
                 is now
                 <% status = a.audited_changes['status'].last %>
                 <%= resource_status_badge status %>
-                for space:
+                for space
                 <%= link_to a.associated_descriptor, project_path(a.associated_id), class: 'text-monospace' %>
               <% end %>
             <% end %>
           <%- when 'request_delete' -%>
             <%= activity_entry resource_icon(a.auditable_model_name), a.created_at do %>
               <% if a.user_email %>
-                <%= a.user_email %> requested deletion of resource:
+                <%= a.user_email %> requested deletion of resource
               <% else %>
-                A resource has been requested to be deleted:
+                A resource has been requested to be deleted
               <% end %>
               <%= a.user_email %>
               <span class="font-weight-bold">
@@ -79,21 +138,21 @@
               </span>
               <% status = 'deleting' %>
               <%= resource_status_badge status %>
-              for space:
+              for space
               <%= link_to a.associated_descriptor, project_path(a.associated_id), class: 'text-monospace' %>
             <% end %>
           <%- when 'destroy' -%>
             <%= activity_entry resource_icon(a.auditable_model_name), a.created_at do %>
               <% if a.user_email %>
-                <%= a.user_email %> deleted resource:
+                <%= a.user_email %> deleted resource
               <% else %>
-                A resource was deleted:
+                A resource was deleted
               <% end %>
               <%= a.user_email %>
               <span class="font-weight-bold">
                 <%= a.auditable_descriptor %>
               </span>
-              for space:
+              for space
               <%= link_to a.associated_descriptor, project_path(a.associated_id), class: 'text-monospace' %>
             <% end %>
           <%- end -%>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -85,6 +85,7 @@
 
     <%= render partial: 'resources', locals: { project: @project, grouped_resources: @grouped_resources } %>
   </div>
+
   <div class="tab-pane" id="activity" role="tabpanel" aria-labelledby="activity-tab">
     <%= render partial: 'activity/stream', locals: { activity: @activity } %>
   </div>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -37,6 +37,9 @@
   <li class="nav-item">
     <a class="nav-link" id="people-tab" data-toggle="tab" href="#people" role="tab" aria-controls="people" aria-selected="false">People</a>
   </li>
+  <li class="nav-item">
+    <a class="nav-link" id="activity-tab" data-toggle="tab" href="#activity" role="tab" aria-controls="activity" aria-selected="false">Activity</a>
+  </li>
 </ul>
 
 <div class="tab-content border border-top-0">
@@ -93,5 +96,9 @@
     <% end %>
 
     <%= render partial: 'people', locals: { team: @team } %>
+  </div>
+
+  <div class="tab-pane" id="activity" role="tabpanel" aria-labelledby="activity-tab">
+    <%= render partial: 'activity/stream', locals: { activity: @activity } %>
   </div>
 </div>

--- a/db/migrate/20190807093015_create_team_memberships.rb
+++ b/db/migrate/20190807093015_create_team_memberships.rb
@@ -1,12 +1,13 @@
 class CreateTeamMemberships < ActiveRecord::Migration[5.2]
   def change
-    create_join_table :teams, :users, table_name: :team_memberships, column_options: { type: :uuid } do |t|
+    create_table :team_memberships, id: :uuid do |t|
+      t.references :team, type: :uuid, null: false, foreign_key: true
+      t.references :user, type: :uuid, null: false, foreign_key: true
+
       t.string :role
 
       t.timestamps
 
-      t.index :user_id
-      t.index :team_id
       t.index %i[team_id user_id], unique: true
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -136,7 +136,7 @@ ActiveRecord::Schema.define(version: 2019_08_07_145601) do
     t.index ["type"], name: "index_resources_on_type"
   end
 
-  create_table "team_memberships", id: false, force: :cascade do |t|
+  create_table "team_memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "team_id", null: false
     t.uuid "user_id", null: false
     t.string "role"
@@ -173,4 +173,6 @@ ActiveRecord::Schema.define(version: 2019_08_07_145601) do
   add_foreign_key "integration_overrides", "projects"
   add_foreign_key "resources", "integrations"
   add_foreign_key "resources", "projects"
+  add_foreign_key "team_memberships", "teams"
+  add_foreign_key "team_memberships", "users"
 end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -9,20 +9,23 @@ RSpec.describe 'Home', type: :request do
     end
 
     it_behaves_like 'authenticated' do
-      let(:activity_service) { instance_double('ActivityService') }
-
       before do
-        expect(ActivityService).to receive(:new)
-          .and_return(activity_service)
-        expect(activity_service).to receive(:overall)
-          .and_return([])
+        # Create some data to show up in the home activity feed
+        team = create :team
+        create :team_membership, :admin, team: team, user: current_user
+        create :project, team: team
+
+        create_list :user, 2
+
+        other_projects = create_list :project, 2
+        other_projects.first.destroy!
       end
 
       it 'loads the homepage' do
         get root_path
         expect(response).to be_successful
         expect(response).to render_template(:show)
-        expect(assigns(:activity)).to eq []
+        expect(assigns(:activity)).not_to be_empty
       end
     end
   end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -45,16 +45,6 @@ RSpec.describe 'Projects', type: :request do
     end
 
     it_behaves_like 'authenticated' do
-      let(:activity_service) { instance_double('ActivityService') }
-
-      before do
-        allow(ActivityService).to receive(:new)
-          .and_return(activity_service)
-        allow(activity_service).to receive(:for_project)
-          .with(@project)
-          .and_return([])
-      end
-
       it_behaves_like 'not a hub admin so not allowed' do
         before do
           get project_path(@project)
@@ -67,7 +57,7 @@ RSpec.describe 'Projects', type: :request do
         expect(response).to render_template(:show)
         expect(assigns(:project)).to eq project
         expect(assigns(:grouped_resources)).to be_present
-        expect(assigns(:activity)).to eq []
+        expect(assigns(:activity)).not_to be_empty
       end
 
       it_behaves_like 'a hub admin' do

--- a/spec/requests/teams_spec.rb
+++ b/spec/requests/teams_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe 'Teams', type: :request do
         expect(response).to be_successful
         expect(response).to render_template(:show)
         expect(assigns(:team)).to eq team
+        expect(assigns(:activity)).not_to be_empty
       end
 
       it_behaves_like 'a hub admin' do


### PR DESCRIPTION
- New activity stream on the team show page for team related activity (excluding resources - for this you need to drill down into individual spaces).
- Lock down the _home_ activity stream to current user's teams and spaces only.

Also as part of this:
- I've fixed the issue where filtering of audits would result in smaller or empty streams than expected – now we:
  1. Have a "fill" mechanism keeps building the list (within a certain time window) until either no more are found in the audits, or the page size is met.
  2. Query very specifically for only the auditable types and actions that are supported in the UI.
- I had to redo the `team_memberships` db table schema as it previously didn't have a primary key, which is now needed for Audits to work properly.