### PR TITLE
Allocating integrations to teams

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group :test do
   gem 'rspec_junit_formatter', '~> 0.4.1'
   gem 'timecop', '~> 0.9.1'
   gem 'shoulda-matchers', '~> 4.1', '>= 4.1.2'
+  gem 'with_model', '~> 2.1', '>= 2.1.2'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -413,6 +413,8 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    with_model (2.1.2)
+      activerecord (>= 4.2, < 6.0)
     yajl-ruby (1.4.1)
     yaml-safe_load_stream (0.1.1)
 
@@ -467,6 +469,7 @@ DEPENDENCIES
   wait (~> 0.5.3)
   web-console (>= 3.3.0)
   webpacker (~> 4.0, >= 4.0.7)
+  with_model (~> 2.1, >= 2.1.2)
 
 RUBY VERSION
    ruby 2.5.5p157

--- a/app/controllers/integration_overrides_controller.rb
+++ b/app/controllers/integration_overrides_controller.rb
@@ -1,8 +1,10 @@
 class IntegrationOverridesController < ApplicationController
   before_action :find_project
 
+  authorize_resource :project
+
   def show
-    @overrideables = integration_overrides_service.overrideable_integrations
+    @overrideables = integration_overrides_service.overrideable_integrations(@project)
 
     @overrides_by_integration_id = @project
       .integration_overrides

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -14,11 +14,19 @@ class ProjectsController < ApplicationController
   end
 
   def show
+    integrations_by_provider = TeamIntegrationsService
+      .get(@project.team)
+      .group_by(&:provider_id)
+
     @grouped_resources = ResourceTypesService.all.map do |rt|
       next nil unless rt[:top_level]
 
-      integrations = ResourceTypesService.integrations_for rt[:id]
+      integrations = rt[:providers].reduce([]) do |acc, p|
+        acc + Array(integrations_by_provider[p])
+      end
+
       resources = @project.send(rt[:id].tableize).order(:name)
+
       rt.merge integrations: integrations, resources: resources
     end.compact
 

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -1,0 +1,41 @@
+class Allocation < ApplicationRecord
+  audited associated_with: :allocation_receivable
+
+  belongs_to :allocatable,
+    -> { readonly },
+    polymorphic: true,
+    inverse_of: :allocations
+
+  belongs_to :allocation_receivable,
+    -> { readonly },
+    polymorphic: true,
+    inverse_of: :allocations
+
+  validate :ensure_uniqueness
+
+  scope :by_allocatable, ->(a) { where(allocatable: a) }
+  scope :by_allocation_receivable, ->(ar) { where(allocation_receivable: ar) }
+
+  attr_readonly :allocatable_type, :allocatable_id, :allocation_receivable_type, :allocation_receivable_id
+
+  def descriptor
+    [
+      "#{allocatable_type}: #{allocatable.descriptor}",
+      '|',
+      "#{allocation_receivable_type}: #{allocation_receivable.descriptor}"
+    ].join(' ')
+  end
+
+  private
+
+  def ensure_uniqueness
+    return if allocatable.blank? || allocation_receivable.blank?
+
+    if Allocation.where(
+      allocatable: allocatable,
+      allocation_receivable: allocation_receivable
+    ).exists?
+      errors[:base] << 'An allocation already exists for this'
+    end
+  end
+end

--- a/app/models/concerns/allocatable.rb
+++ b/app/models/concerns/allocatable.rb
@@ -1,0 +1,17 @@
+module Allocatable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def allocatable
+      has_many :allocations,
+        as: :allocatable,
+        dependent: :restrict_with_exception,
+        inverse_of: :allocatable
+
+      scope :unallocated, lambda {
+        left_outer_joins(:allocations)
+          .where('allocations.allocatable_id IS NULL')
+      }
+    end
+  end
+end

--- a/app/models/concerns/allocation_receivable.rb
+++ b/app/models/concerns/allocation_receivable.rb
@@ -1,0 +1,12 @@
+module AllocationReceivable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def allocation_receivable
+      has_many :allocations,
+        as: :allocation_receivable,
+        dependent: :restrict_with_exception,
+        inverse_of: :allocation_receivable
+    end
+  end
+end

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -1,7 +1,10 @@
 class Integration < ApplicationRecord
   include EncryptedConfigHashAttribute
+  include Allocatable
 
   audited
+
+  allocatable
 
   enum provider_id: PROVIDERS_REGISTRY.ids.each_with_object({}) { |id, acc| acc[id] = id }
 
@@ -19,6 +22,11 @@ class Integration < ApplicationRecord
     presence: true,
     if: :requires_a_parent?
 
+  has_many :teams,
+    through: :allocations,
+    source: :allocation_receivable,
+    source_type: Team.name
+
   has_many :resources,
     dependent: :restrict_with_exception,
     inverse_of: :integration
@@ -29,6 +37,8 @@ class Integration < ApplicationRecord
     inverse_of: :integration
 
   validate :check_parents
+
+  validate :check_teams
 
   def provider
     return if provider_id.blank?
@@ -115,5 +125,19 @@ class Integration < ApplicationRecord
       end
     end
     errors.add(:parent_ids, 'cannot link this to a parent as it already has a child integration of the same type') if has_existing_child
+  end
+
+  def check_teams
+    # Shouldn't be able to allocate teams to this integration if it's meant to be a dependent
+    return unless requires_a_parent?
+    return if team_ids.blank?
+
+    errors.add(
+      :teams,
+      [
+        'not allowed to be allocated to any teams as this is meant to be a',
+        'dependent integration that inherits it\'s allocations from it\'s parent(s)'
+      ].join(' ')
+    )
   end
 end

--- a/app/models/integration_override.rb
+++ b/app/models/integration_override.rb
@@ -14,6 +14,8 @@ class IntegrationOverride < ApplicationRecord
   validates :integration_id,
     uniqueness: { scope: :project_id }
 
+  validate :check_integration_is_allowed
+
   attr_readonly :project_id, :integration_id
 
   def config_schema
@@ -32,5 +34,20 @@ class IntegrationOverride < ApplicationRecord
 
   def descriptor
     "For space: #{project.friendly_id} - integration: #{integration.name}"
+  end
+
+  private
+
+  def check_integration_is_allowed
+    return if project.blank? || integration.blank?
+
+    allowed_integrations = TeamIntegrationsService.get project.team
+
+    return if allowed_integrations.include?(integration)
+
+    errors.add(
+      :integration,
+      'cannot use the integration specified as it\'s not allowed for the project'
+    )
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,6 +1,7 @@
 class Team < ApplicationRecord
   include SluggedAttribute
   include FriendlyId
+  include AllocationReceivable
 
   audited
   has_associated_audits
@@ -12,7 +13,14 @@ class Team < ApplicationRecord
 
   friendly_id :slug
 
+  allocation_receivable
+
   validates :name, presence: true
+
+  has_many :integrations,
+    through: :allocations,
+    source: :allocatable,
+    source_type: Integration.name
 
   has_many :projects,
     -> { order(:name) },

--- a/app/services/dependent_integrations_service.rb
+++ b/app/services/dependent_integrations_service.rb
@@ -5,7 +5,7 @@ module DependentIntegrationsService
         .for_provider(provider_id)
         .fetch(:depends_on, [])
         .map { |parent_provider_id| ResourceTypesService.for_provider parent_provider_id }
-        .map { |resource_type| ResourceTypesService.integrations_for resource_type[:id] }
+        .map { |resource_type| Integration.where provider_id: resource_type[:providers] }
         .flatten
         .group_by { |i| i.provider['name'] }
     end

--- a/app/services/integration_overrides_service.rb
+++ b/app/services/integration_overrides_service.rb
@@ -1,7 +1,8 @@
 class IntegrationOverridesService
-  def overrideable_integrations
-    Integration
-      .order(:provider_id)
+  def overrideable_integrations(project)
+    TeamIntegrationsService
+      .get(project.team)
+      .sort_by(&:provider_id)
       .each_with_object([]) do |i, acc|
         provider = i.provider
 

--- a/app/services/project_resources_bootstrap_service.rb
+++ b/app/services/project_resources_bootstrap_service.rb
@@ -7,10 +7,15 @@ class ProjectResourcesBootstrapService
   def prepare_bootstrap
     return false if @project.resources.count.positive?
 
+    project_integrations = TeamIntegrationsService.get @project.team
+
     ResourceTypesService.all.map do |rt|
       next nil unless rt[:top_level]
 
-      integration = ResourceTypesService.integrations_for(rt[:id]).first
+      integration = project_integrations.find do |i|
+        rt[:providers].include? i.provider_id
+      end
+
       resource = {
         name: @project.slug,
         integration: integration

--- a/app/services/resource_types_service.rb
+++ b/app/services/resource_types_service.rb
@@ -72,13 +72,5 @@ module ResourceTypesService
     def for_integration(integration)
       for_provider integration.provider_id
     end
-
-    def integrations_for(id)
-      entry = get id
-
-      Integration
-        .where(provider_id: entry[:providers])
-        .order(:created_at)
-    end
   end
 end

--- a/app/services/team_integrations_service.rb
+++ b/app/services/team_integrations_service.rb
@@ -1,0 +1,27 @@
+module TeamIntegrationsService
+  class << self
+    def get(team, include_dependents: false)
+      # Assumption: dependent integrations are never allocated, so will only ever
+      # be in the pool of unallocated (thus requiring checking their parents instead).
+
+      integrations = [
+        Integration.unallocated.entries,
+        team.integrations
+      ].flatten
+
+      integrations
+        .select do |i|
+          if include_dependents
+            if i.parents.blank?
+              true
+            else
+              i.parents.any? { |p| integrations.include?(p) }
+            end
+          else
+            ResourceTypesService.for_provider(i.provider_id)[:top_level]
+          end
+        end
+        .sort_by(&:name)
+    end
+  end
+end

--- a/app/views/admin/integrations/_card.html.erb
+++ b/app/views/admin/integrations/_card.html.erb
@@ -15,30 +15,51 @@
       <%= pluralize integration.resources.count, 'resource' %>
     </p>
 
+    <div class="card bg-light p-3 mb-3">
+      <% if group[:top_level] %>
+        <% teams = integration.teams %>
+        <% if teams.present? %>
+          <h6 class="font-weight-bold">Allocated to team(s)</h6>
+          <% teams.each do |t| %>
+            <div class="indented mb-1">
+              <%= link_to t.name, team_path(t) %>
+            </div>
+          <% end %>
+        <% else %>
+          <p class="mb-0">
+            Not allocated to any specific teams
+            <strong>so will be available to ALL teams</strong>
+          </p>
+        <% end %>
+      <% else %>
+        <p class="mb-0">
+          Allocation of this integration is based on it's parent(s) allocation
+        </p>
+      <% end %>
+    </div>
+
     <% parents = integration.parents %>
     <% children = integration.children %>
     <% if parents.present? || children.present? %>
-      <hr />
-
-      <% if parents.present? %>
-        <h6 class="font-weight-bold">Depends on</h6>
-        <% parents.each do |p| %>
-          <div class="indented mb-1">
-            <%= link_to p.name, admin_integrations_path_with_selected(p) %>
-          </div>
+      <div class="card bg-light p-3 mb-3">
+        <% if parents.present? %>
+          <h6 class="font-weight-bold">Depends on</h6>
+          <% parents.each do |p| %>
+            <div class="indented mb-1">
+              <%= link_to p.name, admin_integrations_path_with_selected(p) %>
+            </div>
+          <% end %>
         <% end %>
-      <% end %>
 
-      <% if children.present? %>
-        <h6 class="font-weight-bold">Has dependents</h6>
-        <% children.each do |c| %>
-          <div class="indented mb-1">
-            <%= link_to c.name, admin_integrations_path_with_selected(c) %>
-          </div>
+        <% if children.present? %>
+          <h6 class="font-weight-bold">Has dependents</h6>
+          <% children.each do |c| %>
+            <div class="indented mb-1">
+              <%= link_to c.name, admin_integrations_path_with_selected(c) %>
+            </div>
+          <% end %>
         <% end %>
-      <% end %>
-
-      <hr />
+      </div>
     <% end %>
 
     <%=

--- a/app/views/admin/integrations/_form.html.erb
+++ b/app/views/admin/integrations/_form.html.erb
@@ -15,18 +15,40 @@
   <%= form.text_field :name, layout: :default, input_group_class: 'input-group-lg' %>
 
   <% if @potential_parents.present? %>
-    <%=
-      form.select :parent_ids,
-        @potential_parents.transform_values { |l| l.map { |i| [i.name, i.id] }},
-        {
-          label: 'Link with parent(s)',
-          layout: :default
-        },
-        {
-          class: 'selectpicker',
-          multiple: true
-        }
-    %>
+    <div class="card p-3 mb-3">
+      <%=
+        form.select :parent_ids,
+          @potential_parents.transform_values { |l| l.map { |i| [i.name, i.id] }},
+          {
+            label: 'Link with parent(s)',
+            layout: :default,
+            wrapper: { class: 'mb-0' }
+          },
+          {
+            class: 'selectpicker',
+            multiple: true
+          }
+      %>
+    </div>
+  <% end %>
+
+  <% if @potential_teams.present? %>
+    <div class="card p-3 mb-3">
+      <%=
+        form.select :team_ids,
+          @potential_teams.map { |t| [t.name, t.id] },
+          {
+            label: 'Allocate to team(s)',
+            layout: :default,
+            wrapper: { class: 'mb-0' },
+            help: 'If nothing selected then this integration will be available to ALL teams'
+          },
+          {
+            class: 'selectpicker',
+            multiple: true
+          }
+      %>
+    </div>
   <% end %>
 
   <div class="card mb-3">

--- a/app/views/integration_overrides/show.html.erb
+++ b/app/views/integration_overrides/show.html.erb
@@ -4,8 +4,14 @@
 </h1>
 
 <p class="text-muted">
-  Note: only integrations with overridable config options are shown here
+  Note: only integrations that are allocated to the space AND with overridable config options are shown here
 </p>
+
+<% if @overrideables.blank? %>
+  <p class="none-text">
+    No integrations
+  </p>
+<% end %>
 
 <%=
   bootstrap_form_with(
@@ -71,5 +77,7 @@
     <% end %>
   <% end %>
 
-  <%= form.primary 'Save' %>
+  <% if @overrideables.present? %>
+    <%= form.primary 'Save' %>
+  <% end %>
 <% end %>

--- a/app/views/me/access/show.html.erb
+++ b/app/views/me/access/show.html.erb
@@ -10,7 +10,7 @@
 
       <% if group[:entries].empty? %>
         <p class="lead none-text">
-          No integrations are currently available for this resource type - a hub admin can set up a new integration if required.
+          No integrations available or allocated - contact a hub admin to set up and allocate a new integration if required.
         </p>
       <% else %>
         <% group[:entries].each do |entry| %>

--- a/app/views/projects/_resources.html.erb
+++ b/app/views/projects/_resources.html.erb
@@ -7,7 +7,7 @@
         <span class="float-right">
           <%=
             icon_with_tooltip(
-              'No integrations are currently available for this resource type - a hub admin can set up a new integration if required',
+              'No integrations are currently available in the project for this resource type - a hub admin can set up and allocate a new integration if required',
               icon_name: 'exclamation-circle'
             )
           %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,14 +1,14 @@
 <nav aria-label="breadcrumb" class="mb-3">
-    <ol class="breadcrumb">
-      <li class="breadcrumb-item">
-        <%= link_to team_path(@project.team) do %>
-          <%= icon 'angle-left' %>
-          <%= team_icon %>
-          <%= @project.team.name %>
-        <% end %>
-      </li>
-    </ol>
-  </nav>
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item">
+      <%= link_to team_path(@project.team) do %>
+        <%= icon 'angle-left' %>
+        <%= team_icon %>
+        <%= @project.team.name %>
+      <% end %>
+    </li>
+  </ol>
+</nav>
 
 <% if can? :edit, @project %>
   <div class="btn-group float-right" role="group" aria-label="Space actions">

--- a/app/views/resources/_form.html.erb
+++ b/app/views/resources/_form.html.erb
@@ -18,11 +18,11 @@
 
   <%=
     form.select :integration_id,
-      integrations.map { |i| [i.name, i.id] },
+      integrations.transform_values { |l| l.map { |i| [i.name, i.id] } },
       {
         label: label_with_tooltip(
           'For integration',
-          'These are set up by a hub admin'
+          'These are set up and allocated by a hub admin'
         ),
         required: true
       },
@@ -40,71 +40,73 @@
       pattern: "^#{Resource::SLUG_FORMAT_REGEX}$"
   %>
 
-  <% integrations.each do |i| %>
-    <div data-target="resource-form.section" data-integration-id="<%= i.id -%>">
-      <%- case i.provider_id -%>
-      <%- when 'git_hub' -%>
-        <div class="card my-4">
-          <div class="card-header">
-            Initialise from a template?
-          </div>
-          <div class="card-body">
-            <% enabled = current_user.identities.exists?(integration_id: i.id) %>
+  <% integrations.values.each do |l| %>
+    <% l.each do |i| %>
+      <div data-target="resource-form.section" data-integration-id="<%= i.id -%>">
+        <%- case i.provider_id -%>
+        <%- when 'git_hub' -%>
+          <div class="card my-4">
+            <div class="card-header">
+              Initialise from a template?
+            </div>
+            <div class="card-body">
+              <% enabled = current_user.identities.exists?(integration_id: i.id) %>
 
-            <% unless enabled %>
-              <div class="card bg-light mb-3">
-                <div class="card-body p-2">
-                  You can only use templates once you've
-                  <%= link_to 'connected up your GitHub identity', me_access_path(anchor: i.id) %>.
-                  This is because we use the
-                  <%= link_to 'GitHub Source Imports API', 'https://developer.github.com/v3/migrations/source_imports/' %>
-                  which requires a User-to-Server auth token.
+              <% unless enabled %>
+                <div class="card bg-light mb-3">
+                  <div class="card-body p-2">
+                    You can only use templates once you've
+                    <%= link_to 'connected up your GitHub identity', me_access_path(anchor: i.id) %>.
+                    This is because we use the
+                    <%= link_to 'GitHub Source Imports API', 'https://developer.github.com/v3/migrations/source_imports/' %>
+                    which requires a User-to-Server auth token.
+                  </div>
                 </div>
-              </div>
-            <% end %>
-
-            <%= form.fields_for :git_hub do |integration_form| %>
-              <% templates = i.config['templates'] %>
-              <% if templates.present? %>
-                <%=
-                  integration_form.select :template_url,
-                    templates.map { |t|
-                      [
-                        "#{t['name']} (#{t['repo_url']})",
-                        t['repo_url']
-                      ]
-                    },
-                    {
-                      label: label_with_tooltip(
-                        'Choose from existing options',
-                        'These are set up by a hub admin'
-                      ),
-                      selected: params.dig('resource', 'git_hub', 'template_url'),
-                      include_blank: true
-                    },
-                    {
-                      class: 'selectpicker',
-                      disabled: !enabled
-                    }
-                %>
-
-                <p class="font-weight-bold">
-                  OR
-                </p>
               <% end %>
 
-              <%=
-                integration_form.url_field :template_url_custom,
-                  value: params.dig('resource', 'git_hub', 'template_url_custom'),
-                  disabled: !enabled,
-                  label: 'Specify a custom template repo URL',
-                  help: "Needs to be compatible with #{link_to('the GitHub Source Imports API', 'https://developer.github.com/v3/migrations/source_imports/', target: '_blank')}".html_safe
-              %>
-            <% end %>
+              <%= form.fields_for :git_hub do |integration_form| %>
+                <% templates = i.config['templates'] %>
+                <% if templates.present? %>
+                  <%=
+                    integration_form.select :template_url,
+                      templates.map { |t|
+                        [
+                          "#{t['name']} (#{t['repo_url']})",
+                          t['repo_url']
+                        ]
+                      },
+                      {
+                        label: label_with_tooltip(
+                          'Choose from existing options',
+                          'These are set up by a hub admin'
+                        ),
+                        selected: params.dig('resource', 'git_hub', 'template_url'),
+                        include_blank: true
+                      },
+                      {
+                        class: 'selectpicker',
+                        disabled: !enabled
+                      }
+                  %>
+
+                  <p class="font-weight-bold">
+                    OR
+                  </p>
+                <% end %>
+
+                <%=
+                  integration_form.url_field :template_url_custom,
+                    value: params.dig('resource', 'git_hub', 'template_url_custom'),
+                    disabled: !enabled,
+                    label: 'Specify a custom template repo URL',
+                    help: "Needs to be compatible with #{link_to('the GitHub Source Imports API', 'https://developer.github.com/v3/migrations/source_imports/', target: '_blank')}".html_safe
+                %>
+              <% end %>
+            </div>
           </div>
-        </div>
-      <%- end -%>
-    </div>
+        <%- end -%>
+      </div>
+    <% end %>
   <% end %>
 
   <%= form.primary 'Request' %>

--- a/db/migrate/20190820151439_create_allocations.rb
+++ b/db/migrate/20190820151439_create_allocations.rb
@@ -1,0 +1,32 @@
+class CreateAllocations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :allocations, id: :uuid do |t|
+      t.references :allocatable,
+        type: :uuid,
+        polymorphic: true,
+        null: false,
+        index: {
+          name: 'index_allocations_on_al_type_and_al_id'
+        }
+
+      t.references :allocation_receivable,
+        type: :uuid,
+        polymorphic: true,
+        null: false,
+        index: {
+          name: 'index_allocations_on_al_rec_type_and_al_rec_id'
+        }
+
+      t.timestamps
+
+      t.index %i[
+        allocatable_type
+        allocatable_id
+        allocation_receivable_type
+        allocation_receivable_id
+      ],
+      name: 'index_allocations_on_al_and_al_rec_unique',
+      unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_07_145601) do
+ActiveRecord::Schema.define(version: 2019_08_20_151439) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -32,6 +32,18 @@ ActiveRecord::Schema.define(version: 2019_08_07_145601) do
     t.index ["created_by_id"], name: "index_admin_tasks_on_created_by_id"
     t.index ["data"], name: "index_admin_tasks_on_data", using: :gin
     t.index ["type"], name: "index_admin_tasks_on_type"
+  end
+
+  create_table "allocations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "allocatable_type", null: false
+    t.uuid "allocatable_id", null: false
+    t.string "allocation_receivable_type", null: false
+    t.uuid "allocation_receivable_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["allocatable_type", "allocatable_id", "allocation_receivable_type", "allocation_receivable_id"], name: "index_allocations_on_al_and_al_rec_unique", unique: true
+    t.index ["allocatable_type", "allocatable_id"], name: "index_allocations_on_al_type_and_al_id"
+    t.index ["allocation_receivable_type", "allocation_receivable_id"], name: "index_allocations_on_al_rec_type_and_al_rec_id"
   end
 
   create_table "audits", force: :cascade do |t|

--- a/spec/factories/allocations.rb
+++ b/spec/factories/allocations.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :allocation do
+  end
+end

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe Allocation, type: :model do
+  include_context 'allocation test models'
+
+  describe 'ensure_uniqueness custom validation' do
+    let(:allocatable) { AllocatableModel.create }
+    let(:other_allocatable) { AllocatableModel.create }
+    let(:allocation_receivable) { AllocationReceivableModel.create }
+    let(:other_allocation_receivable) { AllocationReceivableModel.create }
+
+    it 'should not allow allocating the same things more than once' do
+      allocation = Allocation.new(
+        allocatable: allocatable,
+        allocation_receivable: allocation_receivable
+      )
+      expect(allocation).to be_valid
+      allocation.save!
+
+      # Can't create the same allocation
+      allocation = Allocation.new(
+        allocatable: allocatable,
+        allocation_receivable: allocation_receivable
+      )
+      expect(allocation).not_to be_valid
+
+      # But can still create another allocation for the same receiveable
+      allocation = Allocation.new(
+        allocatable: other_allocatable,
+        allocation_receivable: allocation_receivable
+      )
+      expect(allocation).to be_valid
+      allocation.save!
+
+      # Or still create another allocation of the allocatable
+      allocation = Allocation.new(
+        allocatable: allocatable,
+        allocation_receivable: other_allocation_receivable
+      )
+      expect(allocation).to be_valid
+      allocation.save!
+    end
+  end
+end

--- a/spec/models/concerns/allocatable_spec.rb
+++ b/spec/models/concerns/allocatable_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Allocatable, type: :model do
+  include_context 'allocation test models'
+
+  describe '#unallocated scope' do
+    context 'with no allocations made' do
+      it 'should return an empty list' do
+        expect(AllocatableModel.unallocated.entries).to eq []
+      end
+    end
+
+    context 'with some allocations made' do
+      let!(:unallocated_item_1) { AllocatableModel.create! }
+      let!(:unallocated_item_2) { AllocatableModel.create! }
+      let!(:allocated_item_1) { AllocatableModel.create! }
+      let!(:allocated_item_2) { AllocatableModel.create! }
+
+      before do
+        Allocation.create!(
+          allocatable: allocated_item_1,
+          allocation_receivable: AllocationReceivableModel.create!
+        )
+
+        Allocation.create!(
+          allocatable: allocated_item_2,
+          allocation_receivable: AllocationReceivableModel.create!
+        )
+
+        Allocation.create!(
+          allocatable: allocated_item_2,
+          allocation_receivable: AllocationReceivableModel.create!
+        )
+      end
+
+      it 'returns only those allocatable items that have not been allocated at least once' do
+        expect(AllocatableModel.unallocated.pluck(:id)).to contain_exactly(unallocated_item_1.id, unallocated_item_2.id)
+      end
+    end
+  end
+end

--- a/spec/models/integration_override_spec.rb
+++ b/spec/models/integration_override_spec.rb
@@ -14,4 +14,31 @@ RSpec.describe IntegrationOverride, type: :model do
     it { is_expected.to belong_to(:integration).class_name('Integration') }
     it { is_expected.to have_readonly_attribute(:integration_id) }
   end
+
+  describe 'check_integration_is_allowed custom validation' do
+    let(:project) { create :project }
+    let(:other_project) { create :project }
+
+    let(:integration_1) { create_mocked_integration }
+    let(:integration_2) { create_mocked_integration }
+
+    before do
+      create :allocation, allocatable: integration_2, allocation_receivable: other_project.team
+    end
+
+    context 'for an integration that\'s open to all projects' do
+      it 'allows using the integration' do
+        override = build :integration_override, project: project, integration: integration_1
+        expect(override).to be_valid
+      end
+    end
+
+    context 'for an integration that\'s not accessible to the project' do
+      it 'doesn\'t allow using the integration' do
+        override = build :integration_override, project: project, integration: integration_2
+        expect(override).not_to be_valid
+        expect(override.errors[:integration]).to be_present
+      end
+    end
+  end
 end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+RSpec.describe Resource, type: :model do
+  let :test_class do
+    Class.new(Resource) {}
+  end
+
+  let(:project) { create :project }
+  let(:user) { create :user }
+
+  let(:other_project) { create :project }
+
+  let(:integration_1) { create_mocked_integration }
+  let(:integration_2) { create_mocked_integration }
+
+  before do
+    create :allocation, allocatable: integration_2, allocation_receivable: other_project.team
+  end
+
+  describe 'check_integration_is_allowed custom validation' do
+    context 'for an integration that\'s open to all projects' do
+      it 'allows using the integration' do
+        resource = test_class.new(
+          name: 'resource-1',
+          project: project,
+          integration: integration_1,
+          requested_by: user
+        )
+        expect(resource).to be_valid
+      end
+    end
+
+    context 'for an integration that\'s not accessible to the project' do
+      it 'doesn\'t allow using the integration' do
+        resource = test_class.new(
+          name: 'resource-1',
+          project: project,
+          integration: integration_2,
+          requested_by: user
+        )
+        expect(resource).not_to be_valid
+        expect(resource.errors[:integration]).to be_present
+      end
+    end
+
+    context 'when the resource has a parent' do
+      it 'still allows using the integration that\'s open to all projects' do
+        parent = test_class.new(
+          name: 'parent-1',
+          project: project,
+          integration: integration_1,
+          requested_by: user
+        )
+        resource = test_class.new(
+          name: 'resource-1',
+          parent: parent,
+          project: project,
+          integration: integration_2,
+          requested_by: user
+        )
+        expect(resource).to be_valid
+      end
+
+      it 'still doesn\'t allow using the integration that\'s not accessible to the project' do
+        parent = test_class.new(
+          name: 'parent-1',
+          project: project,
+          integration: integration_2,
+          requested_by: user
+        )
+        resource = test_class.new(
+          name: 'resource-1',
+          parent: parent,
+          project: project,
+          integration: integration_2,
+          requested_by: user
+        )
+        expect(resource).not_to be_valid
+        expect(resource.errors[:integration]).to be_present
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,6 +29,8 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  config.extend WithModel
+
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   config.use_transactional_fixtures = true

--- a/spec/requests/admin/integrations_spec.rb
+++ b/spec/requests/admin/integrations_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe 'Admin - Integrations', type: :request do
             expect(response).to render_template(:new)
             expect(assigns(:integration)).to be_a Integration
             expect(assigns(:integration)).to be_new_record
+            expect(assigns(:potential_parents)).not_to be nil
+            expect(assigns(:potential_teams)).not_to be nil
           end
         end
       end
@@ -91,6 +93,8 @@ RSpec.describe 'Admin - Integrations', type: :request do
           expect(response).to be_successful
           expect(response).to render_template(:edit)
           expect(assigns(:integration)).to eq @integration
+          expect(assigns(:potential_parents)).not_to be nil
+          expect(assigns(:potential_teams)).not_to be nil
         end
       end
     end
@@ -141,6 +145,9 @@ RSpec.describe 'Admin - Integrations', type: :request do
               expect(integration.config).to eq params[:config].stringify_keys
               expect(integration.created_at.to_i).to eq now.to_i
             end.to change { Integration.count }.by(1)
+
+            expect(assigns(:potential_parents)).to be nil
+            expect(assigns(:potential_teams)).to be nil
           end
 
           it 'logs an Audit' do
@@ -163,6 +170,9 @@ RSpec.describe 'Admin - Integrations', type: :request do
             expect(integration).not_to be_persisted
             expect(integration.errors).to_not be_empty
             expect(integration.errors[:name]).to be_present
+
+            expect(assigns(:potential_parents)).not_to be nil
+            expect(assigns(:potential_teams)).not_to be nil
           end
         end
       end
@@ -210,6 +220,9 @@ RSpec.describe 'Admin - Integrations', type: :request do
               expect(integration.config).to eq @integration.config
               expect(integration.updated_at.to_i).to eq now.to_i
             end.to change { Integration.count }.by(0)
+
+            expect(assigns(:potential_parents)).to be nil
+            expect(assigns(:potential_teams)).to be nil
           end
 
           it 'logs an Audit' do
@@ -231,6 +244,9 @@ RSpec.describe 'Admin - Integrations', type: :request do
             integration = assigns(:integration)
             expect(integration.errors).to_not be_empty
             expect(integration.errors[:name]).to be_present
+
+            expect(assigns(:potential_parents)).not_to be nil
+            expect(assigns(:potential_teams)).not_to be nil
           end
         end
 

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -52,12 +52,16 @@ RSpec.describe 'Project resources', type: :request do
 
     it_behaves_like 'authenticated' do
       def expect_new_resource_page(project, resource_type, integration)
+        expected_integrations = {
+          integration.provider['name'] => [integration]
+        }
+
         get new_project_resource_path(project, type: resource_type)
         expect(response).to be_successful
         expect(response).to render_template(:new)
         expect(assigns(:project)).to eq project
         expect(assigns(:resource_type)[:id]).to eq 'CodeRepo'
-        expect(assigns(:integrations)).to eq [integration]
+        expect(assigns(:integrations)).to eq expected_integrations
         expect(assigns(:resource)).to be_a Resource
         expect(assigns(:resource)).to be_new_record
       end

--- a/spec/services/team_integrations_service_spec.rb
+++ b/spec/services/team_integrations_service_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe TeamIntegrationsService, type: :service do
+  describe '.get' do
+    let!(:team_1) { create :team }
+    let!(:team_2) { create :team }
+
+    let!(:integration_1) do
+      create_mocked_integration provider_id: 'git_hub'
+    end
+    let!(:integration_2) do
+      create_mocked_integration provider_id: 'quay'
+    end
+    let!(:integration_3) do
+      create_mocked_integration provider_id: 'kubernetes'
+    end
+    let!(:integration_4) do
+      create_mocked_integration provider_id: 'kubernetes'
+    end
+    let!(:integration_3_dependent) do
+      create_mocked_integration provider_id: 'grafana', parent_ids: [integration_3.id]
+    end
+    let!(:integration_4_dependent) do
+      create_mocked_integration provider_id: 'grafana', parent_ids: [integration_4.id]
+    end
+
+    before do
+      create :allocation, allocatable: integration_2, allocation_receivable: team_1
+      create :allocation, allocatable: integration_4, allocation_receivable: team_2
+    end
+
+    context 'when `include_dependents` is `false` (default)' do
+      it 'returns the appropriate integrations for each team' do
+        expect(
+          TeamIntegrationsService.get(team_1)
+        ).to contain_exactly(
+          integration_1,
+          integration_2,
+          integration_3
+        )
+
+        expect(
+          TeamIntegrationsService.get(team_2)
+        ).to contain_exactly(
+          integration_1,
+          integration_3,
+          integration_4
+        )
+      end
+    end
+
+    context 'when `include_dependents` is `true`' do
+      it 'returns the appropriate integrations for each team' do
+        expect(
+          TeamIntegrationsService.get(team_1, include_dependents: true)
+        ).to contain_exactly(
+          integration_1,
+          integration_2,
+          integration_3,
+          integration_3_dependent
+        )
+
+        expect(
+          TeamIntegrationsService.get(team_2, include_dependents: true)
+        ).to contain_exactly(
+          integration_1,
+          integration_3,
+          integration_3_dependent,
+          integration_4,
+          integration_4_dependent
+        )
+      end
+    end
+  end
+end

--- a/spec/support/allocation_test_models.rb
+++ b/spec/support/allocation_test_models.rb
@@ -1,0 +1,29 @@
+module AllocationTestModels
+  RSpec.shared_context 'allocation test models' do
+    with_model :AllocatableModel do
+      table id: :uuid, &:timestamps
+
+      model do
+        include Allocatable
+        allocatable
+
+        def descriptor
+          'N/A'
+        end
+      end
+    end
+
+    with_model :AllocationReceivableModel do
+      table id: :uuid, &:timestamps
+
+      model do
+        include AllocationReceivable
+        allocation_receivable
+
+        def descriptor
+          'N/A'
+        end
+      end
+    end
+  end
+end

--- a/spec/support/mocked_integration_helper.rb
+++ b/spec/support/mocked_integration_helper.rb
@@ -17,10 +17,10 @@ module MockedIntegrationHelper
     end
 
     def create_mocked_integration(provider_id: Integration.provider_ids.keys.first, config: { 'foo' => 'bar' }, schema: nil, parent_ids: [])
-      mock_provider_config_schema provider_id, schema: schema
+      mock_provider_config_schema provider_id.to_s, schema: schema
 
       create :integration,
-        provider_id: provider_id,
+        provider_id: provider_id.to_s,
         config: config,
         parent_ids: parent_ids
     end


### PR DESCRIPTION
With these changes, hub admins can now allocate integrations to specific teams, if needed.

By default, if an integration has no allocations it is assumed to be "open" – i.e. available to all teams in the hub.

Dependent integrations cannot be directly allocated, instead they inherit the allocation of their parent(s).

The following are now _locked down_ based on these allocations (i.e. will take into account only the integrations available to the space's team):
- Resource provisioning
- Space resources bootstrap
- Space integration overrides

Additionally, the user's Access page will only show the integrations they have access to from all their teams.

NOTE: we don't currently handle the **deletion** of an allocation properly – in upcoming work we will handle cases like needing to clean up integration overrides and clean up any user identities.

---

**TODO**

- [x] More specs!