### PR TITLE
Lock down the connecting of an identity

### DIFF
--- a/app/controllers/me/access_controller.rb
+++ b/app/controllers/me/access_controller.rb
@@ -10,10 +10,8 @@ module Me
         .group_by(&:integration_id)
         .transform_values(&:first)
 
-      integrations_by_provider = current_user
-        .teams
-        .reduce([]) { |acc, t| acc + TeamIntegrationsService.get(t, include_dependents: true) }
-        .uniq
+      integrations_by_provider = TeamIntegrationsService
+        .for_user(current_user)
         .group_by(&:provider_id)
 
       @groups = ResourceTypesService.all.map do |rt|

--- a/app/controllers/me/identity_flows_controller.rb
+++ b/app/controllers/me/identity_flows_controller.rb
@@ -5,17 +5,17 @@ module Me
       'git_hub_callback' => 'git_hub'
     }.freeze
 
-    # This controller should only ever act on the currently authenticated user,
-    # so we do not need to peform any authorization checks.
-    skip_authorization_check
-
+    # The git_hub_callback action is an open endpoint since GitHub will call back into it.
     skip_before_action :require_authentication, only: :git_hub_callback
+    skip_authorization_check only: :git_hub_callback
 
     before_action :find_integration
 
     before_action :ensure_valid_action_for_integration
 
     def git_hub_start
+      authorize! :connect_identity, @integration
+
       callback_url = URI.join(
         Rails.configuration.base_url,
         me_identity_flow_git_hub_callback_path(integration_id: @integration.id)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -35,6 +35,12 @@ class Ability
     can %i[show edit update destroy], Project do |project|
       can_participate_in_team? project.team, user
     end
+
+    # Identity flows
+
+    can :connect_identity, Integration do |integration|
+      can_use_integration? integration, user
+    end
   end
 
   private
@@ -51,5 +57,11 @@ class Ability
       team.id,
       user.id
     )
+  end
+
+  def can_use_integration?(integration, user)
+    TeamIntegrationsService
+      .for_user(user)
+      .include?(integration)
   end
 end

--- a/app/services/team_integrations_service.rb
+++ b/app/services/team_integrations_service.rb
@@ -23,5 +23,15 @@ module TeamIntegrationsService
         end
         .sort_by(&:name)
     end
+
+    def for_user(user)
+      user
+        .teams
+        .reduce([]) do |acc, t|
+          acc + TeamIntegrationsService.get(t, include_dependents: true)
+        end
+        .uniq
+        .sort_by(&:name)
+    end
   end
 end

--- a/spec/integration/resources/code_repos/git_hub_code_repos_using_template_spec.rb
+++ b/spec/integration/resources/code_repos/git_hub_code_repos_using_template_spec.rb
@@ -60,8 +60,13 @@ RSpec.describe 'Code Repo - GitHub - using a template' do
   let(:user_auth_token) { 'user_auth_token' }
 
   let! :identity do
+    user = resource.requested_by
+
+    # User needs to be in at least one team to access integrations
+    create :team_membership, user: user
+
     create :identity,
-      user: resource.requested_by,
+      user: user,
       integration: integration,
       access_token: user_auth_token
   end

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -1,5 +1,62 @@
 require 'rails_helper'
 
 RSpec.describe Identity, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  subject do
+    user = create :user
+
+    # User needs to be in at least one team to access integrations
+    create :team_membership, user: user
+
+    create :identity, user: user, integration: create_mocked_integration
+  end
+
+  describe '#user' do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to have_readonly_attribute(:user_id) }
+  end
+
+  describe '#integration' do
+    it { is_expected.to belong_to(:integration).class_name('Integration') }
+    it { is_expected.to have_readonly_attribute(:integration_id) }
+  end
+
+  describe 'check_integration_is_allowed custom validation' do
+    let(:user) { create :user }
+
+    let(:team) { create :team }
+    let(:other_team) { create :team }
+
+    let(:integration_1) { create_mocked_integration }
+    let(:integration_2) { create_mocked_integration }
+    let(:integration_3) { create_mocked_integration }
+
+    before do
+      create :allocation, allocatable: integration_2, allocation_receivable: team
+      create :allocation, allocatable: integration_3, allocation_receivable: other_team
+
+      create :team_membership, user: user, team: team
+    end
+
+    context 'for an integration that\'s open to all users' do
+      it 'allows using the integration' do
+        identity = build :identity, user: user, integration: integration_1
+        expect(identity).to be_valid
+      end
+    end
+
+    context 'for an integration that\'s allocated to a team the user is in' do
+      it 'allows using the integration' do
+        identity = build :identity, user: user, integration: integration_2
+        expect(identity).to be_valid
+      end
+    end
+
+    context 'for an integration that\'s allocated to a team the user is not in' do
+      it 'doesn\'t allow using the integration' do
+        identity = build :identity, user: user, integration: integration_3
+        expect(identity).not_to be_valid
+        expect(identity.errors[:integration]).to be_present
+      end
+    end
+  end
 end

--- a/spec/requests/me/identities_spec.rb
+++ b/spec/requests/me/identities_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 RSpec.describe 'Me - Identities', type: :request do
   include_context 'time helpers'
 
+  before do
+    # User needs to be in at least one team to access integrations
+    create :team_membership, user: current_user
+  end
+
   describe 'destroy - DELETE /me/identities/:integration_id' do
     let :integration do
       create_mocked_integration
@@ -17,6 +22,9 @@ RSpec.describe 'Me - Identities', type: :request do
     it_behaves_like 'authenticated' do
       let!(:other_user) { create :user }
       let! :other_identity do
+        # User needs to be in at least one team to access integrations
+        create :team_membership, user: other_user
+
         create :identity, user: other_user, integration: integration
       end
 

--- a/spec/services/team_integrations_service_spec.rb
+++ b/spec/services/team_integrations_service_spec.rb
@@ -1,34 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe TeamIntegrationsService, type: :service do
+  let!(:team_1) { create :team }
+  let!(:team_2) { create :team }
+
+  let!(:integration_1) do
+    create_mocked_integration provider_id: 'git_hub'
+  end
+  let!(:integration_2) do
+    create_mocked_integration provider_id: 'quay'
+  end
+  let!(:integration_3) do
+    create_mocked_integration provider_id: 'kubernetes'
+  end
+  let!(:integration_4) do
+    create_mocked_integration provider_id: 'kubernetes'
+  end
+  let!(:integration_3_dependent) do
+    create_mocked_integration provider_id: 'grafana', parent_ids: [integration_3.id]
+  end
+  let!(:integration_4_dependent) do
+    create_mocked_integration provider_id: 'grafana', parent_ids: [integration_4.id]
+  end
+
+  before do
+    create :allocation, allocatable: integration_2, allocation_receivable: team_1
+    create :allocation, allocatable: integration_4, allocation_receivable: team_2
+  end
+
   describe '.get' do
-    let!(:team_1) { create :team }
-    let!(:team_2) { create :team }
-
-    let!(:integration_1) do
-      create_mocked_integration provider_id: 'git_hub'
-    end
-    let!(:integration_2) do
-      create_mocked_integration provider_id: 'quay'
-    end
-    let!(:integration_3) do
-      create_mocked_integration provider_id: 'kubernetes'
-    end
-    let!(:integration_4) do
-      create_mocked_integration provider_id: 'kubernetes'
-    end
-    let!(:integration_3_dependent) do
-      create_mocked_integration provider_id: 'grafana', parent_ids: [integration_3.id]
-    end
-    let!(:integration_4_dependent) do
-      create_mocked_integration provider_id: 'grafana', parent_ids: [integration_4.id]
-    end
-
-    before do
-      create :allocation, allocatable: integration_2, allocation_receivable: team_1
-      create :allocation, allocatable: integration_4, allocation_receivable: team_2
-    end
-
     context 'when `include_dependents` is `false` (default)' do
       it 'returns the appropriate integrations for each team' do
         expect(
@@ -70,6 +70,38 @@ RSpec.describe TeamIntegrationsService, type: :service do
           integration_4_dependent
         )
       end
+    end
+  end
+
+  describe '.for_user' do
+    let!(:user) { create :user }
+
+    let!(:team_3) { create :team }
+
+    let!(:integration_5) do
+      create_mocked_integration provider_id: 'kubernetes'
+    end
+
+    let!(:integration_5_dependent) do
+      create_mocked_integration provider_id: 'grafana', parent_ids: [integration_5.id]
+    end
+
+    before do
+      create :team_membership, user: user, team: team_1
+      create :team_membership, user: user, team: team_3
+    end
+
+    it 'returns just the integrations the user has access to' do
+      expect(
+        TeamIntegrationsService.for_user(user)
+      ).to contain_exactly(
+        integration_1,
+        integration_2,
+        integration_3,
+        integration_3_dependent,
+        integration_5,
+        integration_5_dependent
+      )
     end
   end
 end


### PR DESCRIPTION
Only allow connecting an identity if the user has access to the integration tied to that identity.