### PR TITLE
Prevent logout from throwing an error when running locally

### DIFF
--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -14,7 +14,7 @@
               <%= current_user.email %>
             </a>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarUserDropdown">
-              <%= link_to 'Log out', Rails.configuration.x.auth.logout_url, class: 'dropdown-item' %>
+              <%= link_to 'Log out', Rails.configuration.x.auth.logout_url, class: 'dropdown-item', data: { turbolinks: false } %>
             </div>
           </li>
         </ul>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,13 @@ services:
       - 5432:5432
 
   mock_user_service:
-    image: quay.io/appvia/mock-oidc-user-server:v0.0.3
+    image: quay.io/appvia/mock-oidc-user-server:v0.0.4
     environment:
       - PORT=9000
       - CLIENT_ID=ahub-client
       - CLIENT_SECRET=ahub-secret
       - CLIENT_REDIRECT_URI=http://localhost:3000/oauth/callback
+      - CLIENT_LOGOUT_REDIRECT_URI=http://localhost:3000
     ports:
       - 9000:9000
 


### PR DESCRIPTION
* use latest version of `mock-oidc-user-server` - `v0.0.4`
* specify logout redirect URI
* disable turbolinks on logout link