### PR TITLE
UI: Remove team delete option for now

### DIFF
--- a/app/helpers/teams_helper.rb
+++ b/app/helpers/teams_helper.rb
@@ -3,22 +3,6 @@ module TeamsHelper
     icon 'user-friends'
   end
 
-  def delete_team_link(team, css_class: nil)
-    return unless can?(:destroy, team)
-
-    link_to 'Delete',
-      team_path(team),
-      method: :delete,
-      class: css_class,
-      data: {
-        confirm: 'Are you sure you want to delete this team permanently?',
-        title: "Delete team: #{team.slug}",
-        verify: team.slug,
-        verify_text: "Type '#{team.slug}' to confirm"
-      },
-      role: 'button'
-  end
-
   def delete_team_membership_link(team, user, css_class: nil)
     link_to 'Remove from team',
       team_membership_path(team, user),

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -8,7 +8,6 @@
 
 <% @teams.each do |team| %>
   <% can_access = can? :show, team %>
-  <% can_delete = can? :destroy, team %>
 
   <div class="card shadow-sm mb-3 <%= can_access ? nil : 'bg-light' -%>">
     <div class="card-body">
@@ -32,10 +31,5 @@
         </div>
       <% end %>
     </div>
-    <% if can_delete %>
-      <div class="card-footer text-muted">
-        <%= delete_team_link team, css_class: 'float-right btn btn-danger' %>
-      </div>
-    <% end %>
   </div>
 <% end %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -5,7 +5,6 @@
     </button>
     <div class="dropdown-menu dropdown-menu-right" aria-labelledby="teamActionsGroupDropdown">
       <%= link_to 'Edit', edit_team_path(@team), class: 'dropdown-item' %>
-      <%= delete_team_link @team, css_class: 'dropdown-item' %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
… until we do it properly (ref: https://github.com/appvia/appvia-hub/issues/98).

Note: this still leaves the backend for delete in place, which will fail if you try and delete a team with any spaces or allocations.