### PR TITLE
Change the team name used externally in integrations to be more conformant

### DIFF
--- a/app/services/sync_integration_team_service.rb
+++ b/app/services/sync_integration_team_service.rb
@@ -1,9 +1,9 @@
 module SyncIntegrationTeamService
-  TEAM_PREFIX = '[Hub]'.freeze
+  TEAM_PREFIX = 'hub-'.freeze
 
   class << self
     def build_team_name(slug)
-      "#{TEAM_PREFIX} #{slug}"
+      "#{TEAM_PREFIX}#{slug}"
     end
 
     def sync_team(integration, team)

--- a/spec/integration/resources/code_repos/git_hub_code_repos_integration_spec.rb
+++ b/spec/integration/resources/code_repos/git_hub_code_repos_integration_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Code Repos - GitHub' do
 
     let :agent_create_method_call_success do
       lambda do |agent, resource|
-        team_name = "[Hub] #{resource.project.team.slug}"
+        team_name = "hub-#{resource.project.team.slug}"
 
         expect(agent).to receive(:create_repository)
           .with(resource.name, team_name: team_name, auto_init: true)
@@ -62,7 +62,7 @@ RSpec.describe 'Code Repos - GitHub' do
 
     let :agent_create_method_call_error do
       lambda do |agent, resource|
-        team_name = "[Hub] #{resource.project.team.slug}"
+        team_name = "hub-#{resource.project.team.slug}"
 
         expect(agent).to receive(:create_repository)
           .with(resource.name, team_name: team_name, auto_init: true)

--- a/spec/integration/resources/code_repos/git_hub_code_repos_overridden_config_integration_spec.rb
+++ b/spec/integration/resources/code_repos/git_hub_code_repos_overridden_config_integration_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'Code Repo - GitHub - with overridden config option' do
 
   describe 'request create' do
     it 'agent should receive the overridden config option' do
-      team_name = "[Hub] #{resource.project.team.slug}"
+      team_name = "hub-#{resource.project.team.slug}"
 
       expect(agent).to receive(:create_repository)
         .with(resource.name, team_name: team_name, auto_init: false)

--- a/spec/integration/resources/code_repos/git_hub_code_repos_using_template_spec.rb
+++ b/spec/integration/resources/code_repos/git_hub_code_repos_using_template_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'Code Repo - GitHub - using a template' do
 
   describe 'request create' do
     it 'agent should set up the repo and import from the template' do
-      team_name = "[Hub] #{resource.project.team.slug}"
+      team_name = "hub-#{resource.project.team.slug}"
 
       expect(agent).to receive(:create_repository)
         .with(resource.name, team_name: team_name, auto_init: false)

--- a/spec/integration/teams/git_hub_teams_integration_spec.rb
+++ b/spec/integration/teams/git_hub_teams_integration_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'GitHub teams end-to-end' do
       expect(Sidekiq::Worker.jobs.size).to eq 2
 
       expect(agent).to receive(:create_team)
-        .with('[Hub] team-1', team1.description)
+        .with('hub-team-1', team1.description)
 
       process_jobs
 
@@ -154,7 +154,7 @@ RSpec.describe 'GitHub teams end-to-end' do
       expect(Sidekiq::Worker.jobs.size).to eq 1
 
       expect(agent).to receive(:add_user_to_team)
-        .with('[Hub] team-1', 'foo')
+        .with('hub-team-1', 'foo')
 
       process_jobs
 
@@ -186,7 +186,7 @@ RSpec.describe 'GitHub teams end-to-end' do
       expect(Sidekiq::Worker.jobs.size).to eq 1
 
       expect(agent).to receive(:add_user_to_team)
-        .with('[Hub] team-1', 'bar')
+        .with('hub-team-1', 'bar')
 
       process_jobs
 
@@ -214,10 +214,10 @@ RSpec.describe 'GitHub teams end-to-end' do
       expect(Sidekiq::Worker.jobs.size).to eq 2
 
       expect(agent).to receive(:create_team)
-        .with('[Hub] team-2', team2.description)
+        .with('hub-team-2', team2.description)
 
       expect(agent).to receive(:add_user_to_team)
-        .with('[Hub] team-2', 'bar')
+        .with('hub-team-2', 'bar')
         .twice
 
       process_jobs
@@ -238,7 +238,7 @@ RSpec.describe 'GitHub teams end-to-end' do
       expect(Sidekiq::Worker.jobs.size).to eq 1
 
       expect(agent).to receive(:remove_user_from_team)
-        .with('[Hub] team-1', 'bar')
+        .with('hub-team-1', 'bar')
 
       process_jobs
 
@@ -258,7 +258,7 @@ RSpec.describe 'GitHub teams end-to-end' do
       expect(Sidekiq::Worker.jobs.size).to eq 1
 
       expect(agent).to receive(:add_user_to_team)
-        .with('[Hub] team-1', 'bar')
+        .with('hub-team-1', 'bar')
 
       process_jobs
 
@@ -271,10 +271,10 @@ RSpec.describe 'GitHub teams end-to-end' do
       expect(Sidekiq::Worker.jobs.size).to eq 1
 
       expect(agent).to receive(:remove_user_from_team)
-        .with('[Hub] team-1', 'bar')
+        .with('hub-team-1', 'bar')
 
       expect(agent).to receive(:remove_user_from_team)
-        .with('[Hub] team-2', 'bar')
+        .with('hub-team-2', 'bar')
 
       process_jobs
 
@@ -291,13 +291,13 @@ RSpec.describe 'GitHub teams end-to-end' do
       expect(Sidekiq::Worker.jobs.size).to eq 1
 
       expect(agent).to receive(:delete_team)
-        .with('[Hub] team-2')
+        .with('hub-team-2')
 
       # Does a full sync, so also handles syncing of Team 1 too.
       expect(agent).to receive(:create_team)
-        .with('[Hub] team-1', team1.description)
+        .with('hub-team-1', team1.description)
       expect(agent).to receive(:add_user_to_team)
-        .with('[Hub] team-1', 'foo')
+        .with('hub-team-1', 'foo')
 
       process_jobs
 
@@ -322,7 +322,7 @@ RSpec.describe 'GitHub teams end-to-end' do
       )
 
       expect(agent).to receive(:create_repository)
-        .with(code_repo.name, team_name: '[Hub] team-1', auto_init: true)
+        .with(code_repo.name, team_name: 'hub-team-1', auto_init: true)
         .and_return(agent_create_repo_response)
 
       expect(agent).to receive(:apply_best_practices)
@@ -370,10 +370,10 @@ RSpec.describe 'GitHub teams end-to-end' do
         .at_least(:once)
 
       expect(other_agent).to receive(:create_team)
-        .with('[Hub] team-1', team1.description)
+        .with('hub-team-1', team1.description)
 
       expect(other_agent).to receive(:create_team)
-        .with('[Hub] team-2', team2.description)
+        .with('hub-team-2', team2.description)
 
       process_jobs
 
@@ -394,9 +394,9 @@ RSpec.describe 'GitHub teams end-to-end' do
       expect(Sidekiq::Worker.jobs.size).to eq 1
 
       expect(other_agent).to receive(:add_user_to_team)
-        .with('[Hub] team-1', 'bar')
+        .with('hub-team-1', 'bar')
       expect(other_agent).to receive(:add_user_to_team)
-        .with('[Hub] team-2', 'bar')
+        .with('hub-team-2', 'bar')
 
       process_jobs
 
@@ -423,7 +423,7 @@ RSpec.describe 'GitHub teams end-to-end' do
       expect(Sidekiq::Worker.jobs.size).to eq 2
 
       expect(other_agent).to receive(:create_team)
-        .with('[Hub] team-3', team3.description)
+        .with('hub-team-3', team3.description)
 
       process_jobs
 
@@ -436,11 +436,11 @@ RSpec.describe 'GitHub teams end-to-end' do
       expect(Sidekiq::Worker.jobs.size).to eq 1
 
       expect(agent).to receive(:delete_team)
-        .with('[Hub] team-2')
+        .with('hub-team-2')
         .never
 
       expect(other_agent).to receive(:delete_team)
-        .with('[Hub] team-2')
+        .with('hub-team-2')
 
       process_jobs
 
@@ -457,21 +457,21 @@ RSpec.describe 'GitHub teams end-to-end' do
       expect(Sidekiq::Worker.jobs.size).to eq 1
 
       expect(agent).to receive(:create_team)
-        .with('[Hub] team-1', team1.description)
+        .with('hub-team-1', team1.description)
       expect(agent).to receive(:add_user_to_team)
-        .with('[Hub] team-1', 'foo')
+        .with('hub-team-1', 'foo')
       expect(agent).to receive(:add_user_to_team)
-        .with('[Hub] team-1', 'bar')
+        .with('hub-team-1', 'bar')
         .never
 
       expect(agent).to receive(:create_team)
-        .with('[Hub] team-2', team2.description)
+        .with('hub-team-2', team2.description)
         .never
 
       expect(agent).to receive(:create_team)
-        .with('[Hub] team-3', team3.description)
+        .with('hub-team-3', team3.description)
       expect(agent).to receive(:add_user_to_team)
-        .with('[Hub] team-3', 'foo')
+        .with('hub-team-3', 'foo')
 
       process_jobs
     end


### PR DESCRIPTION
This is now `hub-{team.slug}`, which should be make it more conformant in different integrations (like Kubernetes).