### PR TITLE
Don't allow underscores in slugs

### DIFF
--- a/app/models/concerns/slugged_attribute.rb
+++ b/app/models/concerns/slugged_attribute.rb
@@ -1,8 +1,8 @@
 module SluggedAttribute
   extend ActiveSupport::Concern
 
-  SLUG_FORMAT_REGEX = '[a-z]+[a-z0-9\-_]*'.freeze
-  SLUG_FORMAT_TEXT = 'must start with a letter and can only contain lowercase letters, numbers, hyphens, and underscores'.freeze
+  SLUG_FORMAT_REGEX = '[a-z]+[a-z0-9\-]*'.freeze
+  SLUG_FORMAT_TEXT = 'must start with a letter and can only contain lowercase letters, numbers and hyphens'.freeze
 
   class_methods do
     def slugged_attribute(attribute_name, presence:, uniqueness:, readonly:)

--- a/spec/support/slugged_attribute_examples.rb
+++ b/spec/support/slugged_attribute_examples.rb
@@ -17,10 +17,8 @@ module SluggedAttributeExamples
       is_expected.to allow_values(
         'f',
         'foo',
-        'foo_bar',
         'foo-bar',
         'foo-1',
-        'foo_1',
         'f1obar',
         'foo-bar5'
       ).for(attribute_name)
@@ -29,10 +27,12 @@ module SluggedAttributeExamples
     it do
       is_expected.not_to allow_values(
         'FOO_1',
+        'foo_bar',
         'fOO',
         'Foo',
         'foo bar',
         'foo 1',
+        'foo_1',
         '1-foo',
         '1',
         '-foo',


### PR DESCRIPTION
Fixes #267

This is because Kubernetes doesn't allow underscores in names.