### PR TITLE
Fix integration switching resource form behaviour

### DIFF
--- a/app/views/resources/_form.html.erb
+++ b/app/views/resources/_form.html.erb
@@ -54,7 +54,7 @@
 
   <% integrations.values.each do |l| %>
     <% l.each do |i| %>
-      <div data-target="resource-form.section" data-integration-id="<%= i.id -%>">
+      <fieldset data-target="resource-form.section" data-integration-id="<%= i.id -%>">
         <%- case i.provider_id -%>
         <%- when 'git_hub' -%>
           <div class="card my-4">
@@ -176,7 +176,7 @@
             </div>
           </div>
         <%- end -%>
-      </div>
+      </fieldset>
     <% end %>
   <% end %>
 

--- a/app/webpack/controllers/resource_form_controller.js
+++ b/app/webpack/controllers/resource_form_controller.js
@@ -16,10 +16,14 @@ export default class extends Controller {
 
   showCurrentSection() {
     this.sectionTargets.forEach(el => {
-      el.classList.toggle(
-        'd-none',
-        el.dataset.integrationId !== this.integrationId
-      );
+      /* eslint-disable-next-line prettier/prettier */
+      const isSelectedIntegration = el.dataset.integrationId === this.integrationId;
+      el.classList.toggle('d-none', !isSelectedIntegration);
+      if (isSelectedIntegration) {
+        el.removeAttribute('disabled');
+      } else {
+        el.setAttribute('disabled', 'disabled');
+      }
     });
   }
 


### PR DESCRIPTION
* server renders resource form per integration and JS hides the non-selected one using `display: none` on the container
* elements in a container with `display: none` (or with `display: none` set directly) are still submitted by the browser
* this will cause issues due to duplicate names being used and wrong values being received on the server
* fix this by setting the `disabled` attribute for all the resource form elements as well as hiding the container
* maintain the disabled state rendered by the server, by JS setting the disabled value as `disabled_form`, then only removed `disabled` attribute if value is set to this