### PR TITLE
Azure service broker

### DIFF
--- a/app/helpers/json_schema_helper.rb
+++ b/app/helpers/json_schema_helper.rb
@@ -10,4 +10,8 @@ module JsonSchemaHelper
   def json_schema_one_of_select_list(property_spec)
     property_spec['oneOf'].map { |o| [o['title'], o['enum']&.first || o['title']] }
   end
+
+  def json_schema_process_for_display(data)
+    JsonSchemaHelpers.transform_additional_properties data
+  end
 end

--- a/app/helpers/json_schema_helper.rb
+++ b/app/helpers/json_schema_helper.rb
@@ -6,4 +6,8 @@ module JsonSchemaHelper
         "Example(s): #{e.join(', ')}" if e.present?
       end
   end
+
+  def json_schema_one_of_select_list(property_spec)
+    property_spec['oneOf'].map { |o| [o['title'], o['enum']&.first || o['title']] }
+  end
 end

--- a/app/lib/json_schema_helpers.rb
+++ b/app/lib/json_schema_helpers.rb
@@ -26,4 +26,17 @@ module JsonSchemaHelpers
 
     data
   end
+
+  def self.transform_additional_properties(data)
+    data.each do |_key, param_value|
+      next unless param_value.is_a?(Hash) && param_value.key?('additional_properties')
+
+      param_value['additional_properties'].each do |prop|
+        value = prop['value'] == '' ? nil : prop['value']
+        param_value[prop['key']] = value unless prop['key'].empty?
+      end
+      param_value.delete 'additional_properties'
+      transform_additional_properties param_value
+    end
+  end
 end

--- a/app/views/application/forms/json_schema/_field.html.erb
+++ b/app/views/application/forms/json_schema/_field.html.erb
@@ -19,7 +19,10 @@
         include_blank: include_blank,
         help: help_text
       },
-      { class: 'selectpicker' }
+      {
+        required: is_required,
+        class: 'selectpicker'
+      }
   %>
 <%- when 'integer'  %>
   <%=
@@ -34,15 +37,39 @@
       help: help_text
   %>
 <%- else -%>
-  <%=
-    form.text_field name,
-      value: value,
-      required: is_required,
-      label: label_with_tooltip(
-        config_field_title(name, property_spec),
-        property_spec['description']
-      ),
-      pattern: property_spec['pattern'],
-      help: help_text
-  %>
+  <% if property_spec['oneOf'].present? %>
+    <%=
+      form.select name,
+        json_schema_one_of_select_list(property_spec),
+        {
+          value: value,
+          selected: value,
+          required: is_required,
+          label: label_with_tooltip(
+            config_field_title(name, property_spec),
+            property_spec['description']
+          ),
+          include_blank: include_blank,
+          help: help_text
+        },
+        {
+          multiple: multiple,
+          required: is_required,
+          class: 'selectpicker'
+        }
+    %>
+  <% else %>
+    <%=
+      form.text_field name,
+        value: value,
+        required: is_required,
+        multiple: multiple,
+        label: label_with_tooltip(
+          config_field_title(name, property_spec),
+          property_spec['description']
+        ),
+        pattern: property_spec['pattern'],
+        help: help_text
+    %>
+  <% end %>
 <%- end -%>

--- a/app/views/application/forms/json_schema/_fields.html.erb
+++ b/app/views/application/forms/json_schema/_fields.html.erb
@@ -5,46 +5,66 @@
   <%= form.fields_for namespace, fields_for_options do |fields_form| %>
     <% if property_spec['type'] == 'array' %>
 
-      <div data-controller="form-nested-list">
-        <template data-target="form-nested-list.template">
-          <%=
-            render partial: 'application/forms/json_schema/fields_array_item',
-              locals: {
-                form: fields_form,
-                name: name,
-                property_spec: property_spec,
-                item: {}
-              }
-          %>
-        </template>
+      <% if property_spec['items']['type'] == 'string' && property_spec['items']['oneOf'].present? %>
 
-        <h6>
-          <%=
-            label_with_tooltip(
-              config_field_title(name, property_spec),
-              property_spec['description']
-            )
-          %>
-        </h6>
+        <% is_required = Array(spec['required']).include?(name) %>
+        <%=
+          render partial: 'application/forms/json_schema/field',
+            locals: {
+              form: fields_form,
+              name: name,
+              property_spec: property_spec['items'],
+              is_required: is_required,
+              current_value: current[name],
+              include_blank: is_required,
+              multiple: true
+            }
+        %>
 
-        <div>
-          <% Array(current[name]).each do |item| %>
+      <% else %>
+
+        <div data-controller="form-nested-list">
+          <template data-target="form-nested-list.template">
             <%=
               render partial: 'application/forms/json_schema/fields_array_item',
                 locals: {
                   form: fields_form,
                   name: name,
                   property_spec: property_spec,
-                  item: item || {}
+                  item: {}
                 }
             %>
-          <% end %>
+          </template>
 
-          <div class="mb-3" data-target="form-nested-list.links">
-            <%= link_to "Add", "#", class: "btn btn-sm btn-outline-primary", data: { action: "click->form-nested-list#add" } %>
+          <h6>
+            <%=
+              label_with_tooltip(
+                config_field_title(name, property_spec),
+                property_spec['description']
+              )
+            %>
+          </h6>
+
+          <div>
+            <% Array(current[name]).each do |item| %>
+              <%=
+                render partial: 'application/forms/json_schema/fields_array_item',
+                  locals: {
+                    form: fields_form,
+                    name: name,
+                    property_spec: property_spec,
+                    item: item || {}
+                  }
+              %>
+            <% end %>
+
+            <div class="mb-3" data-target="form-nested-list.links">
+              <%= link_to "Add", "#", class: "btn btn-sm btn-outline-primary", data: { action: "click->form-nested-list#add" } %>
+            </div>
           </div>
         </div>
-      </div>
+
+      <% end %>
 
     <% else %>
 
@@ -63,15 +83,17 @@
 
       <% else %>
 
+        <% is_required = Array(spec['required']).include?(name) %>
         <%=
           render partial: 'application/forms/json_schema/field',
             locals: {
               form: fields_form,
               name: name,
               property_spec: property_spec,
-              is_required: Array(spec['required']).include?(name),
+              is_required: is_required,
               current_value: current[name],
-              include_blank: false
+              include_blank: is_required,
+              multiple: false
             }
         %>
 

--- a/app/views/application/forms/json_schema/_fields.html.erb
+++ b/app/views/application/forms/json_schema/_fields.html.erb
@@ -81,6 +81,19 @@
             }
         %>
 
+        <% if property_spec['additionalProperties'].present? && property_spec['additionalProperties']['type'] == 'string' %>
+
+          <%=
+            render partial: 'application/forms/json_schema/fields_additional_properties',
+              locals: {
+                form: fields_form,
+                name: name,
+                current: Array((current[name] || {})['additional_properties']),
+              }
+          %>
+
+        <% end %>
+
       <% else %>
 
         <% is_required = Array(spec['required']).include?(name) %>

--- a/app/views/application/forms/json_schema/_fields_additional_properties.html.erb
+++ b/app/views/application/forms/json_schema/_fields_additional_properties.html.erb
@@ -1,0 +1,78 @@
+<%= form.fields_for name do |additional_props_container| %>
+
+  <%= additional_props_container.fields_for :additional_properties, { index: nil } do |additional_props_form| %>
+
+    <div class="indented ml-2 mb-3">
+      <div data-controller="form-nested-list">
+
+        <template data-target="form-nested-list.template">
+          <div class="indented nested-object mb-3">
+            <h6>
+              <%= label_with_tooltip('Property', 'Key/value pair') %>
+            </h6>
+            <%=
+              additional_props_form.text_field :key,
+                required: false,
+                label: label_with_tooltip(
+                  'Key',
+                  'Additional property key'
+                )
+            %>
+            <%=
+              additional_props_form.text_field :value,
+                required: false,
+                label: label_with_tooltip(
+                  'Value',
+                  'Additional property value'
+                )
+            %>
+            <div>
+              <%= link_to "Remove", "#", class: "btn btn-sm btn-outline-primary", data: { action: "click->form-nested-list#remove" } %>
+            </div>
+          </div>
+        </template>
+
+        <h6>
+          <%= label_with_tooltip('Additional properties', 'Key/value pairs') %>
+        </h6>
+
+        <div>
+          <% current.each do |item| %>
+            <div class="indented nested-object mb-3">
+              <h6>
+                <%= label_with_tooltip('Property', 'Key/value pair') %>
+              </h6>
+              <%=
+                additional_props_form.text_field :key,
+                  value: item['key'],
+                  required: false,
+                  label: label_with_tooltip(
+                    'Key',
+                    'Additional property key'
+                  )
+              %>
+              <%=
+                additional_props_form.text_field :value,
+                  value: item['value'],
+                  required: false,
+                  label: label_with_tooltip(
+                    'Value',
+                    'Additional property value'
+                  )
+              %>
+              <div>
+                <%= link_to "Remove", "#", class: "btn btn-sm btn-outline-primary", data: { action: "click->form-nested-list#remove" } %>
+              </div>
+            </div>
+          <% end %>
+
+          <div class="mb-3" data-target="form-nested-list.links">
+            <%= link_to "Add", "#", class: "btn btn-sm btn-outline-primary", data: { action: "click->form-nested-list#add" } %>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  <% end %>
+
+<% end %>

--- a/app/views/application/forms/json_schema/_fields_array_item.html.erb
+++ b/app/views/application/forms/json_schema/_fields_array_item.html.erb
@@ -1,14 +1,36 @@
-<%=
-  render(
-    'application/forms/json_schema/fields_nested_object',
-    form: form,
-    name: name,
-    spec: property_spec['items'],
-    current: item,
-    is_array: true
-  ) do
-%>
-  <div>
-    <%= link_to "Remove", "#", class: "btn btn-sm btn-outline-primary", data: { action: "click->form-nested-list#remove" } %>
-  </div>
+<% if property_spec['items']['type'] == 'object' %>
+
+  <%=
+    render(
+      'application/forms/json_schema/fields_nested_object',
+      form: form,
+      name: name,
+      spec: property_spec['items'],
+      current: item,
+      is_array: true
+    ) do
+  %>
+    <div>
+      <%= link_to "Remove", "#", class: "btn btn-sm btn-outline-primary", data: { action: "click->form-nested-list#remove" } %>
+    </div>
+  <% end %>
+
+<% else %>
+
+  <% current = item.is_a?(String) ? item : '' %>
+  <%=
+    render(
+      'application/forms/json_schema/fields_nested_field',
+      form: form,
+      name: name,
+      spec: property_spec['items'],
+      current: current,
+      multiple: true
+    ) do
+  %>
+    <div>
+      <%= link_to "Remove", "#", class: "btn btn-sm btn-outline-primary", data: { action: "click->form-nested-list#remove" } %>
+    </div>
+  <% end %>
+
 <% end %>

--- a/app/views/application/forms/json_schema/_fields_nested_field.html.erb
+++ b/app/views/application/forms/json_schema/_fields_nested_field.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div class: 'indented ml-2 mb-3 nested-object' do %>
+<div class="indented ml-2 mb-3 nested-object">
 
   <% is_required = Array(spec['required']).include?(name) %>
   <%=
@@ -15,4 +15,4 @@
   %>
 
   <%= yield if block_given? %>
-<% end %>
+</div>

--- a/app/views/application/forms/json_schema/_fields_nested_field.html.erb
+++ b/app/views/application/forms/json_schema/_fields_nested_field.html.erb
@@ -1,0 +1,18 @@
+<%= tag.div class: 'indented ml-2 mb-3 nested-object' do %>
+
+  <% is_required = Array(spec['required']).include?(name) %>
+  <%=
+    render partial: 'application/forms/json_schema/field',
+      locals: {
+        form: form,
+        name: name,
+        property_spec: spec,
+        is_required: is_required,
+        current_value: current,
+        include_blank: is_required,
+        multiple: multiple
+      }
+  %>
+
+  <%= yield if block_given? %>
+<% end %>

--- a/app/views/application/forms/json_schema/_fields_nested_object.html.erb
+++ b/app/views/application/forms/json_schema/_fields_nested_object.html.erb
@@ -1,4 +1,5 @@
-<%= tag.div class: 'indented ml-2 mb-3 nested-object' do %>
+<div class="nested-object">
+
   <% if spec['title'] %>
     <h6>
       <%=
@@ -9,16 +10,23 @@
       %>
     </h6>
   <% end %>
-  <%=
-    render partial: 'application/forms/json_schema/fields',
-      locals: {
-        form: form,
-        namespace: name,
-        spec: spec,
-        current: current,
-        is_array: is_array
-      }
-  %>
 
-  <%= yield if block_given? %>
-<% end %>
+  <%= tag.div class: 'indented ml-2 mb-3' do %>
+
+    <% if spec['properties'] %>
+      <%=
+        render partial: 'application/forms/json_schema/fields',
+          locals: {
+            form: form,
+            namespace: name,
+            spec: spec,
+            current: current,
+            is_array: is_array
+          }
+      %>
+      <%= yield if block_given? %>
+    <% end %>
+
+  <% end %>
+
+</div>

--- a/app/views/application/forms/json_schema/_fields_nested_object.html.erb
+++ b/app/views/application/forms/json_schema/_fields_nested_object.html.erb
@@ -1,14 +1,14 @@
-<% if spec['title'] %>
-  <h6>
-    <%=
-      label_with_tooltip(
-        config_field_title(name, spec),
-        spec['description']
-      )
-    %>
-  </h6>
-<% end %>
 <%= tag.div class: 'indented ml-2 mb-3 nested-object' do %>
+  <% if spec['title'] %>
+    <h6>
+      <%=
+        label_with_tooltip(
+          config_field_title(name, spec),
+          spec['description']
+        )
+      %>
+    </h6>
+  <% end %>
   <%=
     render partial: 'application/forms/json_schema/fields',
       locals: {

--- a/app/views/integration_overrides/show.html.erb
+++ b/app/views/integration_overrides/show.html.erb
@@ -45,7 +45,8 @@
                     property_spec: property_spec,
                     is_required: false,
                     current_value: overridden_value,
-                    include_blank: "-- don't override --"
+                    include_blank: "-- don't override --",
+                    multiple: false
                   }
               %>
               <p>

--- a/app/views/resources/_form.html.erb
+++ b/app/views/resources/_form.html.erb
@@ -54,7 +54,7 @@
 
   <% integrations.values.each do |l| %>
     <% l.each do |i| %>
-      <fieldset data-target="resource-form.section" data-integration-id="<%= i.id -%>">
+      <fieldset class="border-0 p-0" data-target="resource-form.section" data-integration-id="<%= i.id -%>">
         <%- case i.provider_id -%>
         <%- when 'git_hub' -%>
           <div class="card my-4">

--- a/app/views/resources/_service_catalog_instance_list.html.erb
+++ b/app/views/resources/_service_catalog_instance_list.html.erb
@@ -41,7 +41,7 @@
               locals: {
                 icon: 'keyboard',
                 link_text: 'Create parameters',
-                body_text: JSON.pretty_generate(r.create_parameters)
+                body_text: JSON.pretty_generate(json_schema_process_for_display(r.create_parameters))
               }
           %>
 

--- a/app/webpack/controllers/form_nested_list_controller.js
+++ b/app/webpack/controllers/form_nested_list_controller.js
@@ -13,6 +13,11 @@ export default class extends Controller {
 
     const content = this.templateTarget.innerHTML;
     this.linksTarget.insertAdjacentHTML('beforebegin', content);
+    // setup tooltips in newly created elements
+    /* eslint-disable no-undef */
+    $('[data-toggle="tooltip"]').tooltip();
+    $(window).trigger('load.bs.select.data-api');
+    /* eslint-enable no-undef */
   }
 
   remove(event) {

--- a/app/webpack/controllers/form_nested_list_controller.js
+++ b/app/webpack/controllers/form_nested_list_controller.js
@@ -13,7 +13,7 @@ export default class extends Controller {
 
     const content = this.templateTarget.innerHTML;
     this.linksTarget.insertAdjacentHTML('beforebegin', content);
-    // setup tooltips in newly created elements
+    // setup tooltips and bootstrap-select in newly created elements
     /* eslint-disable no-undef */
     $('[data-toggle="tooltip"]').tooltip();
     $(window).trigger('load.bs.select.data-api');

--- a/app/workers/resources/request_create_worker.rb
+++ b/app/workers/resources/request_create_worker.rb
@@ -60,14 +60,19 @@ module Resources
       },
       'Resources::ServiceCatalogInstance' => {
         'service_catalog' => lambda do |resource, agent, _config|
+          create_parameters = resource.create_parameters.deep_dup
+          JsonSchemaHelpers.transform_additional_properties create_parameters
+
           result = agent.create_resource(
             namespace: resource.parent.name,
             cluster_service_class_external_name: resource.class_external_name,
             cluster_service_plan_external_name: resource.plan_external_name,
             name: resource.name,
-            parameters: resource.create_parameters
+            parameters: create_parameters
           )
+
           resource.service_instance = result.to_hash
+
           true
         end
       }

--- a/spec/lib/json_schema_helpers_spec.rb
+++ b/spec/lib/json_schema_helpers_spec.rb
@@ -1,91 +1,168 @@
 require 'rails_helper'
 
 RSpec.describe JsonSchemaHelpers do
-  let :input_spec do
-    JsonSchema.parse!(
-      'properties' => {
-        'a_string' => { 'type' => 'string' },
-        'a_boolean' => { 'type' => 'boolean' },
-        'an_integer' => { 'type' => 'integer' },
-        'embedded_object' => {
-          'type' => 'object',
-          'properties' => {
-            'a_string' => { 'type' => 'string' },
-            'a_boolean' => { 'type' => 'boolean' },
-            'an_integer' => { 'type' => 'integer' }
-          }
-        },
-        'embedded_array_of_objects' => {
-          'type' => 'array',
-          'items' => {
+  describe '#ensure_data_types' do
+    let :input_spec do
+      JsonSchema.parse!(
+        'properties' => {
+          'a_string' => { 'type' => 'string' },
+          'a_boolean' => { 'type' => 'boolean' },
+          'an_integer' => { 'type' => 'integer' },
+          'embedded_object' => {
             'type' => 'object',
             'properties' => {
               'a_string' => { 'type' => 'string' },
               'a_boolean' => { 'type' => 'boolean' },
               'an_integer' => { 'type' => 'integer' }
             }
+          },
+          'embedded_array_of_objects' => {
+            'type' => 'array',
+            'items' => {
+              'type' => 'object',
+              'properties' => {
+                'a_string' => { 'type' => 'string' },
+                'a_boolean' => { 'type' => 'boolean' },
+                'an_integer' => { 'type' => 'integer' }
+              }
+            }
+          }
+        }
+      )
+    end
+
+    let :input_data do
+      {
+        'a_string' => 'foo',
+        'a_boolean' => 'true',
+        'an_integer' => '42',
+        'embedded_object' => {
+          'a_string' => 'foo',
+          'a_boolean' => 'true',
+          'an_integer' => '42'
+        },
+        'embedded_array_of_objects' => [
+          {
+            'a_string' => 'foo',
+            'a_boolean' => 'true',
+            'an_integer' => '42'
+          },
+          {
+            'a_string' => 'foo',
+            'a_boolean' => 'true',
+            'an_integer' => '42'
+          }
+        ]
+      }
+    end
+
+    let :expected_output do
+      {
+        'a_string' => 'foo',
+        'a_boolean' => true,
+        'an_integer' => 42,
+        'embedded_object' => {
+          'a_string' => 'foo',
+          'a_boolean' => true,
+          'an_integer' => 42
+        },
+        'embedded_array_of_objects' => [
+          {
+            'a_string' => 'foo',
+            'a_boolean' => true,
+            'an_integer' => 42
+          },
+          {
+            'a_string' => 'foo',
+            'a_boolean' => true,
+            'an_integer' => 42
+          }
+        ]
+      }
+    end
+    it 'converts data types to the expected schema data types as expected' do
+      expect(
+        JsonSchemaHelpers.ensure_data_types(
+          input_data,
+          input_spec
+        )
+      ).to eq expected_output
+    end
+  end
+
+  describe '#transform_additional_properties' do
+    let :input do
+      {
+        'person' => {
+          'additional_properties' => [
+            { 'key' => 'first_name', 'value' => 'fred' },
+            { 'key' => 'last_name', 'value' => 'flintstone' }
+          ]
+        }
+      }
+    end
+
+    let :input_nested do
+      {
+        'person' => {
+          'additional_properties' => [
+            { 'key' => 'first_name', 'value' => 'fred' },
+            { 'key' => 'last_name', 'value' => 'flintstone' }
+          ],
+          'address' => {
+            'additional_properties' => [
+              { 'key' => 'house_number', 'value' => '1A' },
+              { 'key' => 'post_code', 'value' => 'SE1 2AB' }
+            ]
           }
         }
       }
-    )
-  end
+    end
 
-  let :input_data do
-    {
-      'a_string' => 'foo',
-      'a_boolean' => 'true',
-      'an_integer' => '42',
-      'embedded_object' => {
-        'a_string' => 'foo',
-        'a_boolean' => 'true',
-        'an_integer' => '42'
-      },
-      'embedded_array_of_objects' => [
-        {
-          'a_string' => 'foo',
-          'a_boolean' => 'true',
-          'an_integer' => '42'
-        },
-        {
-          'a_string' => 'foo',
-          'a_boolean' => 'true',
-          'an_integer' => '42'
+    let :expected do
+      {
+        'person' => {
+          'first_name' => 'fred',
+          'last_name' => 'flintstone'
         }
-      ]
-    }
-  end
+      }
+    end
 
-  let :expected_output do
-    {
-      'a_string' => 'foo',
-      'a_boolean' => true,
-      'an_integer' => 42,
-      'embedded_object' => {
-        'a_string' => 'foo',
-        'a_boolean' => true,
-        'an_integer' => 42
-      },
-      'embedded_array_of_objects' => [
-        {
-          'a_string' => 'foo',
-          'a_boolean' => true,
-          'an_integer' => 42
-        },
-        {
-          'a_string' => 'foo',
-          'a_boolean' => true,
-          'an_integer' => 42
+    let :expected_nested do
+      {
+        'person' => {
+          'first_name' => 'fred',
+          'last_name' => 'flintstone',
+          'address' => {
+            'house_number' => '1A',
+            'post_code' => 'SE1 2AB'
+          }
         }
-      ]
-    }
-  end
+      }
+    end
 
-  it 'converts data types to the expected schema data types as expected' do
-    expect(
-      JsonSchemaHelpers.ensure_data_types(
-        input_data,
-        input_spec
-      )
-    ).to eq expected_output
+    it 'transforms the additional properties directly onto the parent hash' do
+      JsonSchemaHelpers.transform_additional_properties input
+      expect(input).to eq expected
+    end
+
+    it 'does not transform one with an empty key' do
+      input['person']['additional_properties'].first['key'] = ''
+      expected['person'].delete 'first_name'
+      JsonSchemaHelpers.transform_additional_properties input
+      expect(input).to eq expected
+    end
+
+    it 'does transform one with an empty value' do
+      input['person']['additional_properties'].second['value'] = ''
+      expected['person']['last_name'] = nil
+      JsonSchemaHelpers.transform_additional_properties input
+      expect(input).to eq expected
+    end
+
+    it 'will transform recursively' do
+      JsonSchemaHelpers.transform_additional_properties input_nested
+      expect(input_nested).to eq expected_nested
+    end
   end
 end


### PR DESCRIPTION
**Fixes and enhancements to JSON schema templates**
* fixing tooltips so they are generated when JS adds new form elements
* fixing `required` attribute on boolean type select element
* adding an extra div around nested object items in order to keep the title in the deleted div
* supporting `oneOf` when used to specify a set of allowed strings using `enum` or just `title`
* supporting string array
* load bootstrap-select when adding nested elements
* support array of strings using `oneOf` - render a multi-select box
* setting `include_blank` in relation to `required`, if field is required `include_blank` must be set

**Supporting use of type string additionalProperties in JSON schema**
* set out as repeating key/value pairs
* processed on the server into properties on the parent
* also fixing style of integration resource `fieldset` wrapper to remove borders and padding

