### PR TITLE
UI: fix new space button

### DIFF
--- a/app/helpers/sidebar_helper.rb
+++ b/app/helpers/sidebar_helper.rb
@@ -16,4 +16,11 @@ module SidebarHelper
       nav_item text, path, icon: icon
     end
   end
+
+  def show_new_project
+    current_user.teams.count.positive? || (
+      current_user.admin? &&
+      Team.count.positive?
+    )
+  end
 end

--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -27,7 +27,7 @@
     </div>
 
     <div class="sidebar-item">
-      <% if current_user.teams.count > 0 %>
+      <% if show_new_project %>
         <%= link_to 'New', new_project_path, class: 'btn btn-sm btn-primary float-right mr-3' %>
       <% end %>
       <%= nav_item 'All Spaces', projects_path %>


### PR DESCRIPTION
Hub admins can still create new spaces even if they aren't a part of team yet (as long as there are teams present).