### PR TITLE
Service catalog JSON schema validation

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -133,9 +133,9 @@ class ResourcesController < ApplicationController
       service_plan = integration_specific_params['service_plan']
       @sb_service.service_class_plan_names(service_class, service_plan)
         .each { |k, v| resource.send "#{k}=", v }
-      resource.create_parameters = integration_specific_params['plan_parameters'] || {}
+      resource.create_parameters = (integration_specific_params['plan_parameters'] || {}).to_hash
       unless resource.create_parameters.empty?
-        resource.create_parameters_schema = @sb_service.service_plan_schema resource.class_name, resource.plan_name
+        resource.create_parameters_json_schema = @sb_service.service_plan_schema resource.class_name, resource.plan_name
       end
     end
   end

--- a/app/helpers/json_schema_helper.rb
+++ b/app/helpers/json_schema_helper.rb
@@ -7,8 +7,10 @@ module JsonSchemaHelper
       end
   end
 
-  def json_schema_one_of_select_list(property_spec)
-    property_spec['oneOf'].map { |o| [o['title'], o['enum']&.first || o['title']] }
+  def json_schema_string_select_list(property_spec)
+    options = property_spec['oneOf'].map { |o| [o['title'], o['enum']&.first || o['title']] } if property_spec['oneOf'].present?
+    options = property_spec['enum'].map { |o| [o, o] } if property_spec['enum'].present?
+    options
   end
 
   def json_schema_process_for_display(data)

--- a/app/lib/json_schema_helpers.rb
+++ b/app/lib/json_schema_helpers.rb
@@ -1,7 +1,7 @@
 module JsonSchemaHelpers
   # Processes a flat Hash of values, ensuring fields are converted to the data
   # type specified in the provided JsonSchema spec.
-  #
+  # rubocop:disable Metrics/PerceivedComplexity
   def self.ensure_data_types(data, spec)
     return data if data.blank?
 
@@ -18,7 +18,7 @@ module JsonSchemaHelpers
           data[name] = ActiveRecord::Type::Boolean.new.cast(data[name])
         elsif property_spec.type.include?('integer')
           data[name] = data[name].to_i
-        elsif data[name] == ''
+        elsif data[name] == '' && Array(spec.required).include?(name)
           data[name] = nil
         end
       end
@@ -26,6 +26,7 @@ module JsonSchemaHelpers
 
     data
   end
+  # rubocop:enable Metrics/PerceivedComplexity
 
   def self.transform_additional_properties(data)
     data.each do |_key, param_value|

--- a/app/lib/json_schema_helpers.rb
+++ b/app/lib/json_schema_helpers.rb
@@ -40,4 +40,8 @@ module JsonSchemaHelpers
       transform_additional_properties param_value
     end
   end
+
+  def self.prepare_for_schema_validation(data, schema)
+    transform_additional_properties ensure_data_types data, schema
+  end
 end

--- a/app/models/concerns/encrypted_config_hash_attribute.rb
+++ b/app/models/concerns/encrypted_config_hash_attribute.rb
@@ -3,7 +3,6 @@ module EncryptedConfigHashAttribute
 
   # Important assumptions:
   # - the presence of a db field `config` of type `text`
-  # - the presence of a method `config_schema`
 
   included do
     crypt_keeper :config,
@@ -11,42 +10,6 @@ module EncryptedConfigHashAttribute
       key: Rails.application.secrets.secret_key_base,
       salt: Rails.application.secrets.secret_salt
 
-    before_validation :process_config
-    validate :validate_config_matches_schema
-
     default_value_for :config, -> { {} }
-  end
-
-  def config=(hash)
-    super hash.try(:to_json)
-  end
-
-  def config
-    value = super
-    value.present? ? JSON.parse(value) : nil
-  end
-
-  private
-
-  def with_config_schema
-    schema = config_schema
-
-    yield schema if schema.present?
-  end
-
-  def process_config
-    return if config.blank?
-
-    with_config_schema do |schema|
-      self.config = JsonSchemaHelpers.ensure_data_types(config, schema)
-    end
-  end
-
-  def validate_config_matches_schema
-    with_config_schema do |schema|
-      schema.validate! config
-    end
-  rescue JsonSchema::AggregateError => e
-    errors.add :config, e.to_s
   end
 end

--- a/app/models/concerns/json_schema_validation.rb
+++ b/app/models/concerns/json_schema_validation.rb
@@ -1,0 +1,44 @@
+module JsonSchemaValidation
+  extend ActiveSupport::Concern
+  # Important assumptions:
+  # - the presence of methods `json_schema` and `json_data_property_name`
+
+  included do
+    before_validation :process_data
+    validate :validate_data_matches_schema
+  end
+
+  def with_json_schema
+    schema = json_schema
+
+    yield schema if schema.present?
+  end
+
+  def with_data
+    data = send json_data_property_name.to_s
+
+    yield data
+  end
+
+  def process_data
+    with_data do |data|
+      return if data.blank?
+
+      with_json_schema do |schema|
+        send "#{json_data_property_name}=", JsonSchemaHelpers.prepare_for_schema_validation(data, schema)
+      end
+    end
+  end
+
+  def validate_data_matches_schema
+    with_json_schema do |schema|
+      with_data do |data|
+        result = schema.validate data
+        result.second.each do |err|
+          path = err.path.reject { |p| p == '#' }.join('_').underscore.humanize
+          errors.add "#{json_data_property_name} #{path}", err.message
+        end
+      end
+    end
+  end
+end

--- a/app/models/resources/service_catalog_instance.rb
+++ b/app/models/resources/service_catalog_instance.rb
@@ -1,5 +1,9 @@
 module Resources
   class ServiceCatalogInstance < Resource
+    include JsonSchemaValidation
+
+    attr_accessor :create_parameters_json_schema
+
     attr_json :class_name, :string
     attr_json :class_external_name, :string
     attr_json :class_display_name, :string
@@ -9,7 +13,6 @@ module Resources
     attr_json :plan_display_name, :string
 
     attr_json :create_parameters, ActiveModel::Type::Value.new
-    attr_json :create_parameters_schema, ActiveModel::Type::Value.new
     attr_json :service_instance, ActiveModel::Type::Value.new
 
     # Can only ever be "attached" to another resource
@@ -23,20 +26,12 @@ module Resources
     validates :plan_external_name, presence: true
     validates :plan_display_name, presence: true
 
-    validate :json_schema_validation
+    def json_schema
+      create_parameters_json_schema
+    end
 
-    private
-
-    def json_schema_validation
-      return if create_parameters_schema.nil?
-
-      to_validate = JsonSchemaHelpers.ensure_data_types create_parameters.to_hash, create_parameters_schema
-      result = create_parameters_schema.validate JsonSchemaHelpers.transform_additional_properties to_validate
-
-      result.second.each do |err|
-        path = err.path.reject { |p| p == '#' }.join('.').underscore.humanize
-        errors.add path, err.message
-      end
+    def json_data_property_name
+      :create_parameters
     end
   end
 end

--- a/app/models/resources/service_catalog_instance.rb
+++ b/app/models/resources/service_catalog_instance.rb
@@ -9,6 +9,7 @@ module Resources
     attr_json :plan_display_name, :string
 
     attr_json :create_parameters, ActiveModel::Type::Value.new
+    attr_json :create_parameters_schema, ActiveModel::Type::Value.new
     attr_json :service_instance, ActiveModel::Type::Value.new
 
     # Can only ever be "attached" to another resource
@@ -21,5 +22,21 @@ module Resources
     validates :plan_name, presence: true
     validates :plan_external_name, presence: true
     validates :plan_display_name, presence: true
+
+    validate :json_schema_validation
+
+    private
+
+    def json_schema_validation
+      return if create_parameters_schema.nil?
+
+      to_validate = JsonSchemaHelpers.ensure_data_types create_parameters.to_hash, create_parameters_schema
+      result = create_parameters_schema.validate JsonSchemaHelpers.transform_additional_properties to_validate
+
+      result.second.each do |err|
+        path = err.path.reject { |p| p == '#' }.join('.').underscore.humanize
+        errors.add path, err.message
+      end
+    end
   end
 end

--- a/app/services/service_catalog_service.rb
+++ b/app/services/service_catalog_service.rb
@@ -18,8 +18,10 @@ class ServiceCatalogService
     service_plans(class_name).find { |p| p.metadata.name == plan_name }
   end
 
-  def service_plan_schema(class_name, plan_name)
+  def service_plan_schema(class_name, plan_name, parse: true)
     schema = service_plan(class_name, plan_name)&.spec&.instanceCreateParameterSchema
+    return JsonSchema.parse!(schema.to_hash.deep_stringify_keys) if schema.present? && parse
+
     schema.to_hash.deep_stringify_keys if schema.present?
   end
 

--- a/app/views/application/forms/json_schema/_field.html.erb
+++ b/app/views/application/forms/json_schema/_field.html.erb
@@ -24,23 +24,46 @@
         class: 'selectpicker'
       }
   %>
-<%- when 'integer'  %>
-  <%=
-    form.number_field name,
-      value: value,
-      required: is_required,
-      label: label_with_tooltip(
-        config_field_title(name, property_spec),
-        property_spec['description']
-      ),
-      pattern: property_spec['pattern'],
-      help: help_text
-  %>
-<%- else -%>
-  <% if property_spec['oneOf'].present? %>
+<%- when 'integer' %>
+  <% if property_spec['oneOf'].present? || property_spec['enum'].present? %>
     <%=
       form.select name,
-        json_schema_one_of_select_list(property_spec),
+        json_schema_string_select_list(property_spec),
+        {
+          value: value,
+          selected: value,
+          required: is_required,
+          label: label_with_tooltip(
+              config_field_title(name, property_spec),
+              property_spec['description']
+          ),
+          include_blank: include_blank,
+          help: help_text
+        },
+        {
+          multiple: multiple,
+          required: is_required,
+          class: 'selectpicker'
+        }
+    %>
+  <% else %>
+    <%=
+      form.number_field name,
+        value: value,
+        required: is_required,
+        label: label_with_tooltip(
+          config_field_title(name, property_spec),
+          property_spec['description']
+        ),
+        pattern: property_spec['pattern'],
+        help: help_text
+    %>
+  <% end %>
+<%- else -%>
+  <% if property_spec['oneOf'].present? || property_spec['enum'].present? %>
+    <%=
+      form.select name,
+        json_schema_string_select_list(property_spec),
         {
           value: value,
           selected: value,

--- a/app/views/resources/_form.html.erb
+++ b/app/views/resources/_form.html.erb
@@ -160,7 +160,7 @@
                       }
                     }
                 %>
-                <% service_plan_schema = sb_service.service_plan_schema(resource.class_name, resource.plan_name) %>
+                <% service_plan_schema = sb_service.service_plan_schema(resource.class_name, resource.plan_name, parse: false) %>
                 <% unless service_plan_schema.nil? %>
                   <%=
                     render partial: 'application/forms/json_schema/fields',

--- a/spec/models/integration_spec.rb
+++ b/spec/models/integration_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Integration, type: :model do
           subject.config = { 'foo' => 1 }
           expect(subject).not_to be_valid
           expect(subject.errors).to_not be_empty
-          expect(subject.errors[:config]).to be_present
+          expect(subject.errors['config Foo']).to be_present
         end
       end
 
@@ -164,7 +164,7 @@ RSpec.describe Integration, type: :model do
             cp.config = cp.config.merge('foo' => 1)
             expect(cp).not_to be_valid
             expect(cp.errors).to_not be_empty
-            expect(cp.errors[:config]).to be_present
+            expect(cp.errors['config Foo']).to be_present
           end
         end
       end

--- a/spec/services/service_catalog_service_spec.rb
+++ b/spec/services/service_catalog_service_spec.rb
@@ -76,14 +76,21 @@ RSpec.describe ServiceCatalogService, type: :service do
 
   describe '#service_plan_schema' do
     it 'retrieves the schema for a specific plan' do
-      plan_schema = @service.service_plan_schema s3_class_name, s3_prod_plan_name
+      plan_schema = @service.service_plan_schema s3_class_name, s3_prod_plan_name, parse: false
       expect(plan_schema['$schema']).to eq 'http://json-schema.org/draft-06/schema#'
       expect(plan_schema['properties']).not_to be_empty
     end
 
+    it 'retrieves the parsed JSON schema for a specific plan' do
+      plan_schema = @service.service_plan_schema s3_class_name, s3_prod_plan_name, parse: true
+      expect(plan_schema).to be_a(JsonSchema::Schema)
+    end
+
     it 'returns nil if no schema can be found' do
-      expect(@service.service_plan_schema(s3_class_name, 'invalid_plan')).to eq nil
-      expect(@service.service_plan_schema('invalid_class', 'invalid_plan')).to eq nil
+      expect(@service.service_plan_schema(s3_class_name, 'invalid_plan', parse: false)).to eq nil
+      expect(@service.service_plan_schema('invalid_class', 'invalid_plan', parse: false)).to eq nil
+      expect(@service.service_plan_schema(s3_class_name, 'invalid_plan', parse: true)).to eq nil
+      expect(@service.service_plan_schema('invalid_class', 'invalid_plan', parse: true)).to eq nil
     end
   end
 

--- a/spec/support/mocked_integration_helper.rb
+++ b/spec/support/mocked_integration_helper.rb
@@ -12,8 +12,8 @@ module MockedIntegrationHelper
       allow(PROVIDERS_REGISTRY).to receive(:config_schemas)
         .and_return(updated_config_schemas)
 
-      allow(schema).to receive(:validate!)
-        .and_return(true)
+      allow(schema).to receive(:validate)
+        .and_return([true, []])
     end
 
     def create_mocked_integration(provider_id: Integration.provider_ids.keys.first, config: { 'foo' => 'bar' }, schema: nil, parent_ids: [])


### PR DESCRIPTION
**JSON schema form generator enum enhancement**
* render a select box when `enum` is found for type `string` or `integer`
* this an alternative way to specify a value must be from a predefined list of values

**Service catalog plan JSON schema validation**
* reusing the schema validation used by the integrations
* refactoring it out for use elsewhere
* maintaining encrypted config hash attribute concern for that purpose only
* permit any parameters under service catalog plan parameters
* enhance `JsonSchemaHelpers.ensure_data_types` to only convert empty strings to `nil` for required properties
* adding new method in `JsonSchemaHelpers` to prepare data for validation
* amending `service_catalog_service` to be able to get a parsed JSON schema
* store the schema on the service catalog instance
