### PR TITLE
Access page now shows unused identities

### DIFF
--- a/app/views/me/access/_entry.html.erb
+++ b/app/views/me/access/_entry.html.erb
@@ -1,0 +1,147 @@
+<% integration = entry[:integration] %>
+<% identity = entry[:identity] %>
+<% project_robot_credentials = entry[:project_robot_credentials] %>
+<% global_credentials = global_credentials_for integration %>
+
+<% requires_identity = ProviderIdentitiesService.requires_identity? integration.provider_id %>
+
+<div id="<%= integration.id -%>" class="card shadow-sm mb-4">
+  <div class="card-header">
+    <strong>
+      Integration: <%= integration.name %>
+    </strong>
+
+    <%= link_to me_access_path(anchor: integration.id) do %>
+      <%= icon 'link', css_class: ['ml-1', 'text-muted'] %>
+    <% end %>
+  </div>
+
+  <ul class="list-group list-group-flush">
+    <li class="list-group-item">
+      <h6 class="font-weight-bold">
+        Personal Access
+      </h6>
+
+      <% if requires_identity %>
+        <% if identity.present? %>
+          <p>
+            <%= icon 'check-circle', css_class: 'green' %>
+            Connected
+          </p>
+
+          <%= render partial: 'identity', locals: { identity: identity } %>
+        <% else %>
+          <p class="mb-0">
+            <%- case integration.provider_id -%>
+            <%- when 'git_hub' -%>
+              <%=
+                link_to(
+                  'Connect your GitHub identity',
+                  me_identity_flow_git_hub_start_path(integration_id: integration.id),
+                  class: 'btn btn-primary float-right ml-4',
+                  role: 'button'
+                )
+              %>
+            <%- end -%>
+
+            <%= icon 'exclamation-triangle', css_class: 'yellow' %>
+
+            <span>
+              Not connected
+            </span>
+          </p>
+        <% end %>
+      <% else %>
+        <p class="mb-0">
+          <%= icon 'info-circle', css_class: 'light-gray' %>
+          The hub doesn't manage personal access for this integration – you may need to speak to your admin to give you access.
+        </p>
+      <% end %>
+    </li>
+
+    <li class="list-group-item">
+      <h6 class="font-weight-bold">
+        Robot Access
+
+        <% if project_robot_credentials.present? %>
+          <%= count_badge project_robot_credentials.size %>
+        <% end %>
+
+        <% if global_credentials.present? %>
+          <%= count_badge 1 %>
+        <% end %>
+      </h6>
+
+      <% project_robot_credentials.each do |prc| %>
+        <div class="card mb-2">
+          <div class="card-body p-3">
+            <p class="card-title font-weight-bold">
+              <%= prc.full_name -%>
+            </p>
+
+            <p class="card-text">
+              For space: <%= prc.owner.name %>
+              (<%= prc.owner.slug %>)
+            </p>
+
+            <div>
+              <% if @unmask %>
+                <pre class="text-wrap bg-light p-3"><code><%= prc.value -%></code></pre>
+
+                <%=
+                  render partial: 'integrations/set_up_access',
+                    locals: {
+                      integration: integration,
+                      credential: prc
+                    }
+                %>
+              <% else %>
+                <%=
+                  link_to 'Reveal all credential values',
+                    {
+                      unmask: true,
+                      anchor: integration.id,
+                    }
+                %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+
+      <% if global_credentials.present? %>
+        <% if @unmask %>
+          <%=
+            render partial: 'integrations/global_credentials',
+              locals: {
+                integration: integration,
+                credentials: global_credentials
+              }
+          %>
+
+          <%=
+            render partial: 'integrations/set_up_access',
+              locals: {
+                integration: integration
+              }
+          %>
+        <% else %>
+          <%=
+            link_to 'Reveal all credential values',
+              {
+                unmask: true,
+                anchor: integration.id,
+              }
+          %>
+        <% end %>
+      <% end %>
+
+      <% if global_credentials.blank? && project_robot_credentials.blank? %>
+        <p class="mb-0">
+          <%= icon 'info-circle', css_class: 'light-gray' %>
+          No robot access available for this integration.
+        </p>
+      <% end %>
+    </li>
+  </ul>
+</div>

--- a/app/views/me/access/_identity.html.erb
+++ b/app/views/me/access/_identity.html.erb
@@ -1,0 +1,27 @@
+<div class="card p-2 bg-light">
+  <dl class="row mb-0">
+    <% data = identity.external_info %>
+    <% data.each do |(k, v)| %>
+      <dt class="col-sm-3"><%= k -%></dt>
+      <dd class="col-sm-9"><%= v -%></dd>
+    <% end %>
+  </dl>
+
+  <div>
+    <%=
+      link_to(
+        'Disconnect',
+        me_identity_path(integration_id: identity.integration.id),
+        method: :delete,
+        class: 'btn btn-primary float-right ml-4',
+        role: 'button',
+        data: {
+          confirm: 'Are you sure you want to disconnect this identity from this integration? This will remove you from any relevant teams within the org, so you may lose access to repositories.',
+          title: "Disconnect identity for this integration and lose access",
+          verify: 'yes',
+          verify_text: "Type 'yes' to confirm"
+        }
+      )
+    %>
+  </div>
+</div>

--- a/app/views/me/access/show.html.erb
+++ b/app/views/me/access/show.html.erb
@@ -1,6 +1,34 @@
 <h1>Access</h1>
 
 <section class="my-access">
+  <% if @unused_identities.present? %>
+    <div class="card border-danger mb-3">
+      <div class="card-body">
+        <h3 class="card-title text-danger">
+          Unused identities
+        </h3>
+
+        <p class="card-text">
+          <%= icon 'question-circle' %>
+          These are identities you previously connected in the hub but now unneeded,
+          due to access to the integration being removed from your team(s).
+        </p>
+      </div>
+
+      <ul class="list-group list-group-flush">
+        <% @unused_identities.each do |ui| %>
+        <li class="list-group-item">
+          <h6 class="font-weight-bold">
+            For integration: <%= ui.integration.name %>
+          </h6>
+
+          <%= render partial: 'identity', locals: { identity: ui } %>
+        </li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
   <% @groups.each do |group| %>
     <div class="integrations-group py-2">
       <h3 class="my-3">
@@ -14,179 +42,7 @@
         </p>
       <% else %>
         <% group[:entries].each do |entry| %>
-          <% integration = entry[:integration] %>
-          <% identity = entry[:identity] %>
-          <% project_robot_credentials = entry[:project_robot_credentials] %>
-          <% global_credentials = global_credentials_for integration %>
-
-          <% requires_identity = ProviderIdentitiesService.requires_identity? integration.provider_id %>
-
-          <div id="<%= integration.id -%>" class="card shadow-sm mb-4">
-            <div class="card-header">
-              <strong>
-                Integration: <%= integration.name %>
-              </strong>
-
-              <%= link_to me_access_path(anchor: integration.id) do %>
-                <%= icon 'link', css_class: ['ml-1', 'text-muted'] %>
-              <% end %>
-            </div>
-
-            <ul class="list-group list-group-flush">
-              <li class="list-group-item">
-                <h6 class="font-weight-bold">
-                  Personal Access
-                </h6>
-
-                <% if requires_identity %>
-                  <% if identity.present? %>
-                    <p>
-                      <%= icon 'check-circle', css_class: 'green' %>
-                      Connected
-                    </p>
-
-                    <div class="card p-2 bg-light">
-                      <dl class="row mb-0">
-                        <% data = identity.external_info %>
-                        <% data.each do |(k, v)| %>
-                          <dt class="col-sm-3"><%= k -%></dt>
-                          <dd class="col-sm-9"><%= v -%></dd>
-                        <% end %>
-                      </dl>
-
-                      <div>
-                        <%=
-                          link_to(
-                            'Disconnect',
-                            me_identity_path(integration_id: integration.id),
-                            method: :delete,
-                            class: 'btn btn-primary float-right ml-4',
-                            role: 'button',
-                            data: {
-                              confirm: 'Are you sure you want to disconnect your GitHub identity from this integration? This will remove you from any relevant teams within the org, so you may lose access to repositories.',
-                              title: "Disconnect GitHub identity for this integration and lose access",
-                              verify: 'yes',
-                              verify_text: "Type 'yes' to confirm"
-                            }
-                          )
-                        %>
-                      </div>
-                    </div>
-                  <% else %>
-                    <p class="mb-0">
-                      <%- case integration.provider_id -%>
-                      <%- when 'git_hub' -%>
-                        <%=
-                          link_to(
-                            'Connect your GitHub identity',
-                            me_identity_flow_git_hub_start_path(integration_id: integration.id),
-                            class: 'btn btn-primary float-right ml-4',
-                            role: 'button'
-                          )
-                        %>
-                      <%- end -%>
-
-                      <%= icon 'exclamation-triangle', css_class: 'yellow' %>
-
-                      <span>
-                        Not connected
-                      </span>
-                    </p>
-                  <% end %>
-                <% else %>
-                  <p class="mb-0">
-                    <%= icon 'info-circle', css_class: 'light-gray' %>
-                    The hub doesn't manage personal access for this integration – you may need to speak to your admin to give you access.
-                  </p>
-                <% end %>
-              </li>
-
-              <li class="list-group-item">
-                <h6 class="font-weight-bold">
-                  Robot Access
-
-                  <% if project_robot_credentials.present? %>
-                    <%= count_badge project_robot_credentials.size %>
-                  <% end %>
-
-                  <% if global_credentials.present? %>
-                    <%= count_badge 1 %>
-                  <% end %>
-                </h6>
-
-                <% project_robot_credentials.each do |prc| %>
-                  <div class="card mb-2">
-                    <div class="card-body p-3">
-                      <p class="card-title font-weight-bold">
-                        <%= prc.full_name -%>
-                      </p>
-
-                      <p class="card-text">
-                        For space: <%= prc.owner.name %>
-                        (<%= prc.owner.slug %>)
-                      </p>
-
-                      <div>
-                        <% if @unmask %>
-                          <pre class="text-wrap bg-light p-3"><code><%= prc.value -%></code></pre>
-
-                          <%=
-                            render partial: 'integrations/set_up_access',
-                              locals: {
-                                integration: integration,
-                                credential: prc
-                              }
-                          %>
-                        <% else %>
-                          <%=
-                            link_to 'Reveal all credential values',
-                              {
-                                unmask: true,
-                                anchor: integration.id,
-                              }
-                          %>
-                        <% end %>
-                      </div>
-                    </div>
-                  </div>
-                <% end %>
-
-                <% if global_credentials.present? %>
-                  <% if @unmask %>
-                    <%=
-                      render partial: 'integrations/global_credentials',
-                        locals: {
-                          integration: integration,
-                          credentials: global_credentials
-                        }
-                    %>
-
-                    <%=
-                      render partial: 'integrations/set_up_access',
-                        locals: {
-                          integration: integration
-                        }
-                    %>
-                  <% else %>
-                    <%=
-                      link_to 'Reveal all credential values',
-                        {
-                          unmask: true,
-                          anchor: integration.id,
-                        }
-                    %>
-                  <% end %>
-                <% end %>
-
-                <% if global_credentials.blank? && project_robot_credentials.blank? %>
-                  <p class="mb-0">
-                    <%= icon 'info-circle', css_class: 'light-gray' %>
-                    No robot access available for this integration.
-                  </p>
-                <% end %>
-              </li>
-            </ul>
-          </div>
+          <%= render partial: 'entry', locals: { entry: entry } %>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
Closes #296

"Unused identities" = identities previously connected in the hub but now unneeded, due to access to the integration being removed from team(s).