### PR TITLE
Fixing clipboard to play nicely with turbo links

### DIFF
--- a/app/webpack/packs/application.js
+++ b/app/webpack/packs/application.js
@@ -67,9 +67,7 @@ document.addEventListener('turbolinks:load', () => {
 
   // Make bootstrap-select work with Turbolinks
   $(window).trigger('load.bs.select.data-api');
-});
 
-$(document).ready(function() {
   const clipboard = new ClipboardJS('.copy-btn');
   clipboard.on('success', function(e) {
     const { originalTitle } = e.trigger.dataset;


### PR DESCRIPTION
* initialise on the `turbolinks:load` event instead of DOM ready