### PR TITLE
Changing version to be written to a file in public directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 /config/master.key
 /public/packs
 /public/packs-test
+/public/version
 /node_modules
 yarn-debug.log*
 .yarn-integrity

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,8 @@ ENV HOME $APP_PATH
 ENV PORT 3001
 ENV RAILS_LOG_TO_STDOUT true
 ENV RAILS_SERVE_STATIC_FILES true
-ENV VERSION ${VERSION}
+
+RUN echo -n ${VERSION:-not-set} > public/version
 
 RUN bundle -v && \
     bundle config --global disable_shared_gems true

--- a/app/controllers/version_controller.rb
+++ b/app/controllers/version_controller.rb
@@ -1,9 +1,0 @@
-class VersionController < ApplicationController
-  skip_before_action :require_authentication, only: :show
-
-  skip_authorization_check
-
-  def show
-    render json: { version: Rails.configuration.version }
-  end
-end

--- a/config/initializers/app_config.rb
+++ b/config/initializers/app_config.rb
@@ -1,3 +1,1 @@
 Rails.application.config.base_url = ENV.fetch('BASE_URL') { raise 'BASE_URL missing from env' }
-
-Rails.application.config.version = ENV.fetch('VERSION', 'not-set')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,8 +61,6 @@ Rails.application.routes.draw do
 
   get '/healthz', to: 'healthcheck#show'
 
-  get '/version', to: 'version#show'
-
   root to: 'home#show'
   mount Sidekiq::Web => '/sidekiq'
 end


### PR DESCRIPTION
* having a `VERSION` env var set interferes with the DB migration
* this is still accessible via the `/version` endpoint