### PR TITLE
Removing padding and margins around each status bar

### DIFF
--- a/app/views/resources/_card.html.erb
+++ b/app/views/resources/_card.html.erb
@@ -118,12 +118,12 @@
   </div>
   <% statuses = resource_status resource %>
   <% if statuses.present? %>
-    <div class="card-footer bg-light">
+    <div class="card-footer bg-light p-0">
     <% statuses.each do |s| %>
       <% if s[:url] %>
         <a href="<%= s[:url] %>" target="_new" rel="noopener noreferrer" class="card-link ml-0">
       <% end %>
-      <div class="row border mb-1 bg-white">
+      <div class="row border m-0 bg-white">
         <div class="col-1 p-1 bg-<%= s[:colour] %> text-center text-white"><%= s[:status] %></div>
         <div class="col-11 p-1">
           <div class="ml-2">


### PR DESCRIPTION
Very minor CSS change, for discussion - take it or leave it, I don't mind.

BEFORE:

<img width="1217" alt="Screen Shot 2019-10-17 at 14 44 20" src="https://user-images.githubusercontent.com/1334068/67015028-c2586880-f0ed-11e9-8906-e0aab50406dd.png">

AFTER:

![Screen Shot 2019-10-17 at 14 39 02](https://user-images.githubusercontent.com/1334068/67015034-c4bac280-f0ed-11e9-8d24-0cfd9153f701.png)
