### PR TITLE
Support teams deletion in the `clean_hub` script (#298)

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,6 +3,7 @@ class Project < ApplicationRecord
   include FriendlyId
 
   audited associated_with: :team
+  has_associated_audits
 
   belongs_to :team
 

--- a/lib/tasks/hub.rake
+++ b/lib/tasks/hub.rake
@@ -1,13 +1,20 @@
+# rubocop:disable Metrics/BlockLength
 namespace :hub do
   namespace :danger_zone do
-    desc 'WARNING: will delete all resources and spaces, '\
-         'together with their audit entries. Note (1): will still delete resources '\
-         'in the db even if agent(s) throw an error for request deletes. '\
-         'Note (2): you can exclude certain spaces by setting the `EXCLUDE_SPACES env var`, '\
-         'e.g.: EXCLUDE_SPACES="foo-1,bar,another-space" bin/rails hub:danger_zone:clean_hub'
+    desc [
+      'WARNING: will delete all resources, spaces and teams,',
+      'together with their audit entries. Note (1): will still delete resources',
+      'in the db even if agent(s) throw an error for request deletes. ',
+      'Note (2): you can exclude certain spaces, and/or teams, by setting th`EXCLUDE_SPACES`, and/or `EXCLUDE_TEAMS`, env vars ',
+      '(using the slugs for spaces and teams as the identifier), ',
+      'e.g.: EXCLUDE_SPACES="foo-1,bar,another-space" EXCLUDE_TEAMS="team-x" bin/rails hub:danger_zone:clean_hub'
+    ].join(' ')
     task clean_hub: :environment do
       exclude_spaces = Array(
         (ENV['EXCLUDE_SPACES'] || '').split(',')
+      ).map(&:strip)
+      exclude_teams = Array(
+        (ENV['EXCLUDE_TEAMS'] || '').split(',')
       ).map(&:strip)
 
       exclude_project_ids = if exclude_spaces.present?
@@ -15,52 +22,87 @@ namespace :hub do
                             else
                               []
                             end
+      exclude_team_ids = if exclude_teams.present?
+                           Team.where(slug: exclude_teams).pluck(:id)
+                         else
+                           []
+                         end
 
       require 'sidekiq/testing'
       Sidekiq::Testing.inline! do
-        HubCleaner.delete_resources exclude_project_ids
-        HubCleaner.delete_projects exclude_project_ids
+        HubCleaner.delete_resources exclude_project_ids, exclude_team_ids
+        HubCleaner.delete_projects exclude_project_ids, exclude_team_ids
+        HubCleaner.delete_teams exclude_team_ids
       end
     end
   end
 end
+# rubocop:enable Metrics/BlockLength
 
 module HubCleaner
   class << self
-    def delete_resources(exclude_project_ids)
+    def delete_resources(exclude_project_ids, exclude_team_ids)
       provisioning_service = ResourceProvisioningService.new
 
       ids = []
 
       Resource.where.not(project_id: exclude_project_ids).each do |r|
+        next if exclude_team_ids.include?(r.project.team_id)
+
         ids << r.id
-        puts "Requesting deletion for resource '#{r.descriptor}' (ID: #{r.id})"
+        Rails.logger.info "Requesting deletion for resource '#{r.descriptor}' (ID: #{r.id})"
         provisioning_service.request_delete r
       rescue ActiveRecord::StaleObjectError
         # Handle optimistic locking error
-        r.reload.destroy if Resource.exists? r.id
+        r.reload.destroy! if Resource.exists? r.id
       end
 
-      # Just in case they've hung around due to errors from the agent
-      Resource.where.not(project_id: exclude_project_ids).destroy_all
+      # Just in case they've hung around due to errors from the agent.
+      Resource.where.not(project_id: exclude_project_ids).each do |r|
+        next if exclude_team_ids.include?(r.project.team_id)
+
+        r.destroy!
+      end
 
       delete_audits_for 'Resource', ids
     end
 
-    def delete_projects(exclude_project_ids)
+    def delete_projects(exclude_project_ids, exclude_team_ids)
       ids = []
 
       Project.where.not(id: exclude_project_ids).each do |p|
+        next if exclude_team_ids.include?(p.team_id)
+
         ids << p.id
-        puts "Requesting deletion for space '#{p.slug}' (ID: #{p.id})"
-        p.destroy
+        Rails.logger.info "Requesting deletion for space '#{p.slug}' (ID: #{p.id})"
+        ProjectsService.destroy!(p)
       end
 
       delete_audits_for 'Project', ids
+      delete_associated_audits_for 'Project', ids
+    end
+
+    def delete_teams(exclude_team_ids)
+      ids = []
+
+      Team.where.not(id: exclude_team_ids).each do |t|
+        next unless t.projects.empty?
+
+        ids << t.id
+        Rails.logger.info "Requesting deletion for team '#{t.slug}' (ID: #{t.id})"
+        TeamsService.destroy!(t)
+      end
+
+      delete_audits_for 'Team', ids
+      delete_associated_audits_for 'Team', ids
     end
 
     def delete_audits_for(auditable_type, auditable_ids)
       Audit.where(auditable_type: auditable_type, auditable_id: auditable_ids).each(&:delete)
+    end
+
+    def delete_associated_audits_for(associated_type, associated_ids)
+      Audit.where(associated_type: associated_type, associated_id: associated_ids).each(&:delete)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,7 @@ require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 require 'sidekiq/testing'
+Sidekiq::Testing.fake!
 Sidekiq::Logging.logger = nil
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -53,6 +54,10 @@ RSpec.configure do |config|
   config.include_context 'mocked integration helper'
 
   config.include_context 'fixture helpers'
+
+  config.before(:suite) do
+    Rails.application.load_tasks
+  end
 
   config.before(:each) do
     Sidekiq::Worker.clear_all

--- a/spec/tasks/hub/clean_hub_spec.rb
+++ b/spec/tasks/hub/clean_hub_spec.rb
@@ -1,0 +1,216 @@
+require 'rails_helper'
+
+RSpec.describe 'bin/rails hub:danger_zone:clean_hub', type: :task do
+  subject do
+    Rake::Task['hub:danger_zone:clean_hub']
+  end
+
+  before do
+    @initial_audit_count = Audit.count
+
+    @integration1 = create_mocked_integration provider_id: 'git_hub'
+    @integration2 = create_mocked_integration provider_id: 'git_hub'
+
+    @user = create :user
+
+    @team1 = create :team
+    @team2 = create :team
+
+    @team1_membership = create :team_membership, team: @team1, user: @user
+    @team2_membership = create :team_membership, team: @team2, user: @user
+
+    create :allocation, allocatable: @integration2, allocation_receivable: @team2
+
+    @team1_project1 = create :project, team: @team1
+    @team1_project2 = create :project, team: @team1
+    @team2_project1 = create :project, team: @team2
+
+    @team1_project1_resource1 = create :code_repo,
+      integration: @integration1,
+      project: @team1_project1,
+      requested_by: @user,
+      full_name: 'foo/resource1'
+    @team2_project1_resource1 = create :code_repo,
+      integration: @integration2,
+      project: @team2_project1,
+      requested_by: @user,
+      full_name: 'foo/resource2s'
+
+    @unaffected_audits_count = 3 # The ones for user(s) + integration(s)
+    @full_audit_count = @initial_audit_count + 13
+
+    # Pre checks
+    expect(Team.count).to eq 2
+    expect(TeamMembership.count).to eq 2
+    expect(Allocation.count).to eq 1
+    expect(Project.count).to eq 3
+    expect(Resource.count).to eq 2
+    expect(@team1.audits.count).to eq 1
+    expect(@team1.associated_audits.count).to eq 3
+    expect(@team2.audits.count).to eq 1
+    expect(@team2.associated_audits.count).to eq 3
+    expect(@team1_project1.audits.count).to eq 1
+    expect(@team1_project1.associated_audits.count).to eq 1
+    expect(@team1_project2.audits.count).to eq 1
+    expect(@team1_project2.associated_audits.count).to eq 0
+    expect(@team2_project1.audits.count).to eq 1
+    expect(@team2_project1.associated_audits.count).to eq 1
+    expect(Audit.count).to eq @full_audit_count
+
+    # Mock out agent(s)
+    @agent = instance_double('GitHubAgent')
+    allow(GitHubAgent).to receive(:new)
+      .with(anything)
+      .and_return(@agent)
+  end
+
+  it 'preloads the Rails environment' do
+    expect(subject.prerequisites).to include 'environment'
+  end
+
+  context 'with no exclusions' do
+    it 'cleans up all resources, projects and teams, along with their relevant audits' do
+      expect(@agent).to receive(:delete_repository)
+        .with(@team1_project1_resource1.full_name)
+        .and_return(true)
+      expect(@agent).to receive(:delete_repository)
+        .with(@team2_project1_resource1.full_name)
+        .and_return(true)
+      expect(@agent).to receive(:delete_team)
+        .with(SyncIntegrationTeamService.build_team_name(@team1.slug))
+        .and_return(true)
+      expect(@agent).to receive(:delete_team)
+        .with(SyncIntegrationTeamService.build_team_name(@team2.slug))
+        .and_return(true)
+        .twice
+
+      subject.execute
+
+      expect(Team.count).to eq 0
+      expect(TeamMembership.count).to eq 0
+      expect(Allocation.count).to eq 0
+      expect(Project.count).to eq 0
+      expect(Resource.count).to eq 0
+      expect(Audit.count).to eq(@initial_audit_count + @unaffected_audits_count)
+    end
+  end
+
+  context 'with some exclusions' do
+    context 'with project exclusion only' do
+      before do
+        ENV['EXCLUDE_SPACES'] = [
+          @team1_project1.slug,
+          @team1_project2.slug
+        ].join(',')
+      end
+
+      after do
+        ENV.delete 'EXCLUDE_SPACES'
+      end
+
+      it 'cleans up just the resources, projects and teams that it should, along with their relevant audits' do
+        expect(@agent).to receive(:delete_repository)
+          .with(@team1_project1_resource1.full_name)
+          .never
+        expect(@agent).to receive(:delete_repository)
+          .with(@team2_project1_resource1.full_name)
+          .and_return(true)
+        expect(@agent).to receive(:delete_team)
+          .with(SyncIntegrationTeamService.build_team_name(@team1.slug))
+          .never
+        expect(@agent).to receive(:delete_team)
+          .with(SyncIntegrationTeamService.build_team_name(@team2.slug))
+          .and_return(true)
+          .twice
+
+        subject.execute
+
+        expect(Team.count).to eq 1
+        expect(TeamMembership.count).to eq 1
+        expect(Allocation.count).to eq 0
+        expect(Project.count).to eq 2
+        expect(Project.pluck(:slug)).to contain_exactly(
+          @team1_project1.slug,
+          @team1_project2.slug
+        )
+        expect(Resource.count).to eq 1
+        expect(Audit.count).to eq(@full_audit_count - 5)
+      end
+    end
+
+    context 'with team exclusion only' do
+      before do
+        ENV['EXCLUDE_TEAMS'] = @team2.slug
+      end
+
+      after do
+        ENV.delete 'EXCLUDE_TEAMS'
+      end
+
+      it 'cleans up just the resources, projects and teams that it should, along with their relevant audits' do
+        expect(@agent).to receive(:delete_repository)
+          .with(@team1_project1_resource1.full_name)
+          .and_return(true)
+        expect(@agent).to receive(:delete_repository)
+          .with(@team2_project1_resource1.full_name)
+          .never
+        expect(@agent).to receive(:delete_team)
+          .with(SyncIntegrationTeamService.build_team_name(@team1.slug))
+          .and_return(true)
+        expect(@agent).to receive(:delete_team)
+          .with(SyncIntegrationTeamService.build_team_name(@team2.slug))
+          .never
+
+        subject.execute
+
+        expect(Team.count).to eq 1
+        expect(TeamMembership.count).to eq 1
+        expect(Allocation.count).to eq 1
+        expect(Project.count).to eq 1
+        expect(Project.pluck(:slug)).to contain_exactly @team2_project1.slug
+        expect(Resource.count).to eq 1
+        expect(Audit.count).to eq(@full_audit_count - 5)
+      end
+    end
+
+    context 'with both project and team exclusions' do
+      before do
+        ENV['EXCLUDE_SPACES'] = @team1_project2.slug
+        ENV['EXCLUDE_TEAMS'] = @team2.slug
+      end
+
+      after do
+        ENV.delete 'EXCLUDE_SPACES'
+        ENV.delete 'EXCLUDE_TEAMS'
+      end
+
+      it 'cleans up just the resources, projects and teams that it should, along with their relevant audits' do
+        expect(@agent).to receive(:delete_repository)
+          .with(@team1_project1_resource1.full_name)
+          .and_return(true)
+        expect(@agent).to receive(:delete_repository)
+          .with(@team2_project1_resource1.full_name)
+          .never
+        expect(@agent).to receive(:delete_team)
+          .with(SyncIntegrationTeamService.build_team_name(@team1.slug))
+          .never
+        expect(@agent).to receive(:delete_team)
+          .with(SyncIntegrationTeamService.build_team_name(@team2.slug))
+          .never
+
+        subject.execute
+
+        expect(Team.count).to eq 2
+        expect(TeamMembership.count).to eq 2
+        expect(Allocation.count).to eq 1
+        expect(Project.count).to eq 2
+        expect(Project.pluck(:slug)).to contain_exactly(
+          @team1_project2.slug,
+          @team2_project1.slug
+        )
+        expect(Resource.count).to eq 1
+        expect(Audit.count).to eq(@full_audit_count - 2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #298 

Highlights:
- Now deletes and cleans up teams.
- New `EXCLUDE_TEAMS` env var to exclude certain teams (works in conjunction with the existing `EXCLUDE_SPACES` env var).
- Projects (aka spaces) are now deleted using the appropriate service object, so that things like robot tokens are cleaned up.